### PR TITLE
[BUGFIX] Fix persistent option in field ViewHelper

### DIFF
--- a/Classes/ViewHelpers/FieldViewHelper.php
+++ b/Classes/ViewHelpers/FieldViewHelper.php
@@ -131,7 +131,7 @@ class FieldViewHelper extends AbstractViewHelper implements CompilableInterface
         SectionViewHelper::resetSectionClosures();
         OptionViewHelper::resetOptions();
 
-        self::restoreOriginalArguments($renderingContext, $originalArguments);
+        self::restoreOriginalArguments($renderingContext, $templateArguments, $originalArguments);
 
         return $result;
     }
@@ -204,11 +204,20 @@ class FieldViewHelper extends AbstractViewHelper implements CompilableInterface
      * Will restore original arguments in the template variable container.
      *
      * @param RenderingContextInterface $renderingContext
+     * @param array                     $templateArguments
      * @param array                     $originalArguments
      */
-    protected static function restoreOriginalArguments(RenderingContextInterface $renderingContext, array $originalArguments)
+    protected static function restoreOriginalArguments(RenderingContextInterface $renderingContext, array $templateArguments, array $originalArguments)
     {
         $templateVariableContainer = $renderingContext->getTemplateVariableContainer();
+
+        $identifiers = $templateVariableContainer->getAllIdentifiers();
+        foreach ($identifiers as $identifier) {
+            if (array_key_exists($identifier, $templateArguments)) {
+                $templateVariableContainer->remove($identifier);
+            }
+        }
+
         foreach ($originalArguments as $key => $value) {
             if (null !== $value) {
                 if ($templateVariableContainer->exists($key)) {


### PR DESCRIPTION
When using the ViewHelper `<formz:option>` inside `<formz:field>`, the option
would not be deleted after the whole field is processed, resulting in unwanted
options in later fields, which could cause pretty ugly behaviours.

For instance, a field could be flagged as required even if it is not.

In the following example, the option `required` would have been present for the
field `bar` (it is now fixed by this commit).

```
<formz:field name="foo">
    <formz:option name="required" value="1" />

    [...]
</formz:field>

<formz:field name="bar">
    [...]
</formz:field>
```