### PR TITLE
[BUGFIX] Fix the js email validator regex

### DIFF
--- a/Resources/Public/JavaScript/Validators/Formz.Validator.Email.js
+++ b/Resources/Public/JavaScript/Validators/Formz.Validator.Email.js
@@ -12,7 +12,7 @@ Formz.Validation.registerValidator(
     function(value, callback, states) {
         if (value !== '') {
             // @see http://emailregex.com/
-            var pattern = /^[-a-z0-9~!$%^&*_=+}{\'?]+(\.[-a-z0-9~!$%^&*_=+}{\'?]+)*@([a-z0-9_][-a-z0-9_]*(\.[-a-z0-9_]+)*\.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}))(:[0-9]{1,5})?$/i;
+            var pattern = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
             if (false === pattern.test(value)) {
                 states['result'].addError({
                     name: 'default',


### PR DESCRIPTION
The old regex had a limited list of tlds.

The new regex allows any ltd in emails and comes from: http://emailregex.com/