### PR TITLE
[TASK] Improve assets inclusion to make it work in backend context 

### DIFF
--- a/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
+++ b/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
@@ -96,7 +96,7 @@ class CssAssetHandlerConnector
 
         $this->assetHandlerConnectorManager
             ->getPageRenderer()
-            ->addCssFile($filePath);
+            ->addCssFile(Core::get()->getResourceRelativePath($filePath));
 
         return $this;
     }

--- a/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
+++ b/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
@@ -14,9 +14,9 @@
 namespace Romm\Formz\AssetHandler\Html;
 
 use Romm\Formz\AssetHandler\AbstractAssetHandler;
+use Romm\Formz\Core\Core;
 use Romm\Formz\Error\FormResult;
 use Romm\Formz\Form\FormInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
@@ -164,7 +164,7 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
      */
     public static function getFieldDataValueKey($fieldName)
     {
-        return 'formz-value-' . self::getFieldCleanName($fieldName);
+        return 'formz-value-' . Core::get()->sanitizeString($fieldName);
     }
 
     /**
@@ -175,7 +175,7 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
      */
     public static function getFieldDataValidKey($fieldName)
     {
-        return 'formz-valid-' . self::getFieldCleanName($fieldName);
+        return 'formz-valid-' . Core::get()->sanitizeString($fieldName);
     }
 
     /**
@@ -186,7 +186,7 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
      */
     public static function getFieldDataErrorKey($fieldName)
     {
-        return 'formz-error-' . self::getFieldCleanName($fieldName);
+        return 'formz-error-' . Core::get()->sanitizeString($fieldName);
     }
 
     /**
@@ -199,17 +199,8 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
      */
     public static function getFieldDataValidationErrorKey($fieldName, $errorTitle)
     {
-        return 'formz-error-' . self::getFieldCleanName($fieldName) . '-' . self::getFieldCleanName(str_replace(':', '-', $errorTitle));
-    }
+        $core = Core::get();
 
-    /**
-     * Replaces underscores with a dash.
-     *
-     * @param string $fieldName
-     * @return string
-     */
-    public static function getFieldCleanName($fieldName)
-    {
-        return str_replace('_', '-', GeneralUtility::camelCaseToLowerCaseUnderscored($fieldName));
+        return 'formz-error-' . $core->sanitizeString($fieldName) . '-' . $core->sanitizeString(str_replace(':', '-', $errorTitle));
     }
 }

--- a/Classes/Condition/Items/FieldHasErrorCondition.php
+++ b/Classes/Condition/Items/FieldHasErrorCondition.php
@@ -15,6 +15,7 @@ namespace Romm\Formz\Condition\Items;
 
 use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
 use Romm\Formz\Condition\Processor\DataObject\PhpConditionDataObject;
+use Romm\Formz\Core\Core;
 use TYPO3\CMS\Extbase\Error\Error;
 
 /**
@@ -125,6 +126,6 @@ class FieldHasErrorCondition extends AbstractConditionItem
      */
     protected function getErrorTitle()
     {
-        return DataAttributesAssetHandler::getFieldCleanName($this->validationName . ':' . $this->errorName);
+        return Core::get()->sanitizeString($this->validationName . ':' . $this->errorName);
     }
 }

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -386,6 +386,23 @@ class Core implements SingletonInterface
     }
 
     /**
+     * Sanitizes a string: lower case with dash separation.
+     *
+     * @param string $string
+     * @return string
+     */
+    public function sanitizeString($string)
+    {
+        $string = str_replace('_', '-', GeneralUtility::camelCaseToLowerCaseUnderscored($string));
+
+        while (strpos($string, '--')) {
+            $string = str_replace('--', '-', $string);
+        }
+
+        return $string;
+    }
+
+    /**
      * @return ObjectManagerInterface
      */
     public function getObjectManager()

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -364,6 +364,10 @@ class Core implements SingletonInterface
     {
         $relativePath = ExtensionManagementUtility::siteRelPath('formz');
 
+        if ($this->environmentService->isEnvironmentInBackendMode()) {
+            $relativePath = '../' . $relativePath;
+        }
+
         return (null !== $path)
             ? $relativePath . $path
             : $relativePath;
@@ -375,13 +379,19 @@ class Core implements SingletonInterface
      */
     public function getResourceRelativePath($path)
     {
-        return rtrim(
+        $relativePath = rtrim(
             PathUtility::getRelativePath(
                 GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT'),
                 GeneralUtility::getFileAbsFileName($path)
             ),
             '/'
         );
+
+        if ($this->environmentService->isEnvironmentInBackendMode()) {
+            $relativePath = '../' . $relativePath;
+        }
+
+        return $relativePath;
     }
 
     /**

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -72,6 +72,11 @@ class Core implements SingletonInterface
     private $formObjectFactory;
 
     /**
+     * @var EnvironmentService
+     */
+    private $environmentService;
+
+    /**
      * Contains the actual language key.
      *
      * @var string
@@ -169,10 +174,7 @@ class Core implements SingletonInterface
     public function getCurrentPageUid()
     {
         if (-1 === $this->currentPageUid) {
-            /** @var EnvironmentService $environmentService */
-            $environmentService = GeneralUtility::makeInstance(EnvironmentService::class);
-
-            $id = ($environmentService->isEnvironmentInFrontendMode())
+            $id = ($this->environmentService->isEnvironmentInFrontendMode())
                 ? $this->getPageController()->id
                 : GeneralUtility::_GP('id');
 
@@ -317,10 +319,7 @@ class Core implements SingletonInterface
         if (null === $this->languageKey) {
             $this->languageKey = 'default';
 
-            /** @var EnvironmentService $environmentService */
-            $environmentService = GeneralUtility::makeInstance(EnvironmentService::class);
-
-            if ($environmentService->isEnvironmentInFrontendMode()) {
+            if ($this->environmentService->isEnvironmentInFrontendMode()) {
                 $pageController = $this->getPageController();
 
                 if (isset($pageController->config['config']['language'])) {
@@ -464,6 +463,22 @@ class Core implements SingletonInterface
     public function injectFormObjectFactory(FormObjectFactory $formObjectFactory)
     {
         $this->formObjectFactory = $formObjectFactory;
+    }
+
+    /**
+     * @return EnvironmentService
+     */
+    public function getEnvironmentService()
+    {
+        return $this->environmentService;
+    }
+
+    /**
+     * @param EnvironmentService $environmentService
+     */
+    public function injectEnvironmentService(EnvironmentService $environmentService)
+    {
+        $this->environmentService = $environmentService;
     }
 
     /**

--- a/Classes/Utility/TypoScriptUtility.php
+++ b/Classes/Utility/TypoScriptUtility.php
@@ -134,17 +134,16 @@ class TypoScriptUtility implements SingletonInterface
 
         if (null === $result) {
             $result = $this->getConfiguration($pageUid);
-
             $result = (ArrayUtility::isValidPath($result, self::EXTENSION_CONFIGURATION_PATH, '.'))
                 ? ArrayUtility::getValueByPath($result, self::EXTENSION_CONFIGURATION_PATH, '.')
                 : [];
 
-            $hash = 'ts-conf-page-' . sha1(serialize($result));
-
-            $cacheInstance->set($hash, $result);
-
-            $this->pagesConfigurationHashes[$pageUid] = $hash;
-            $cacheInstance->set(self::PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER, $this->pagesConfigurationHashes);
+            if (ArrayUtility::isValidPath($result, 'settings.typoScriptIncluded', '.')) {
+                $hash = 'ts-conf-page-' . sha1(serialize($result));
+                $cacheInstance->set($hash, $result);
+                $this->pagesConfigurationHashes[$pageUid] = $hash;
+                $cacheInstance->set(self::PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER, $this->pagesConfigurationHashes);
+            }
         }
 
         return $result;

--- a/Classes/Utility/TypoScriptUtility.php
+++ b/Classes/Utility/TypoScriptUtility.php
@@ -16,6 +16,8 @@ namespace Romm\Formz\Utility;
 use Romm\Formz\Core\Core;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Service\EnvironmentService;
 use TYPO3\CMS\Extbase\Service\TypoScriptService;
 
@@ -25,8 +27,6 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
 class TypoScriptUtility implements SingletonInterface
 {
     const EXTENSION_CONFIGURATION_PATH = 'config.tx_formz';
-
-    const PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER = 'ts-conf-hash-pages';
 
     /**
      * @var EnvironmentService
@@ -43,35 +43,22 @@ class TypoScriptUtility implements SingletonInterface
      *
      * @var array
      */
-    protected $pageConfiguration = [];
+    protected $configuration = [];
 
     /**
-     * @var array
-     */
-    protected $pagesConfigurationHashes;
-
-    /**
-     * Calls the function `getConfigurationFromPath`, but uses the extension
-     * configuration path as root path.
+     * Returns the TypoScript configuration at the given path (starting from
+     * Formz configuration root).
      *
-     * @param string        $path      The path to the configuration value. If null is given, the whole extension configuration is returned.
-     * @param int|null|bool $pageUid   The uid of the page you want the TypoScript configuration from. If `null` is given, the current page uid is used.
-     * @param string        $delimiter The delimiter for the path. Default is ".".
-     * @return mixed|null
+     * @param string $path
+     * @return mixed
      */
-    public function getExtensionConfigurationFromPath($path = null, $pageUid = null, $delimiter = '.')
+    public function getExtensionConfigurationFromPath($path)
     {
-        $extensionConfiguration = $this->getFullExtensionConfiguration($pageUid);
+        $extensionConfiguration = $this->getExtensionConfiguration();
 
-        if (null === $path) {
-            $result = $extensionConfiguration;
-        } else {
-            $result = (ArrayUtility::isValidPath($extensionConfiguration, $path, $delimiter))
-                ? ArrayUtility::getValueByPath($extensionConfiguration, $path, $delimiter)
-                : null;
-        }
-
-        return $result;
+        return (ArrayUtility::isValidPath($extensionConfiguration, $path, '.'))
+            ? ArrayUtility::getValueByPath($extensionConfiguration, $path, '.')
+            : null;
     }
 
     /**
@@ -82,7 +69,7 @@ class TypoScriptUtility implements SingletonInterface
      */
     public function getFormConfiguration($formClassName)
     {
-        $formzConfiguration = $this->getExtensionConfigurationFromPath();
+        $formzConfiguration = $this->getExtensionConfiguration();
 
         return (isset($formzConfiguration['forms'][$formClassName]))
             ? $formzConfiguration['forms'][$formClassName]
@@ -97,52 +84,36 @@ class TypoScriptUtility implements SingletonInterface
      */
     public function getFormzConfiguration()
     {
-        $configuration = $this->getExtensionConfigurationFromPath();
+        $configuration = $this->getExtensionConfiguration();
         unset($configuration['forms']);
 
         return $configuration;
     }
 
     /**
-     * This function will fetch the extension TypoScript configuration. There
-     * are two levels of cache: one cache entry is used to store identifiers for
-     * the second level of configuration caches: for every page id on which
-     * there is a need to access the Formz configuration.
+     * This function will fetch the extension TypoScript configuration, and
+     * store it in cache for further usage.
      *
-     * @param int|null $pageUid The uid of the page you want the TypoScript configuration from. If `null` is given, the current page uid is used.
+     * The configuration array is not stored in cache if the configuration
+     * property `settings.typoScriptIncluded` is not found.
+     *
      * @return array
      */
-    protected function getFullExtensionConfiguration($pageUid = null)
+    protected function getExtensionConfiguration()
     {
-        $result = null;
-        $pageUid = $this->getRealPageUid($pageUid);
         $cacheInstance = Core::get()->getCacheInstance();
+        $hash = $this->getContextHash();
 
-        if (null === $this->pagesConfigurationHashes) {
-            $this->pagesConfigurationHashes = ($cacheInstance->has(self::PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER))
-                ? $cacheInstance->get(self::PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER)
-                : [];
-        }
-
-        if (true === isset($this->pagesConfigurationHashes[$pageUid])) {
-            $hash = $this->pagesConfigurationHashes[$pageUid];
-
-            if ($cacheInstance->has($hash)) {
-                $result = $cacheInstance->get($hash);
-            }
-        }
-
-        if (null === $result) {
-            $result = $this->getConfiguration($pageUid);
+        if ($cacheInstance->has($hash)) {
+            $result = $cacheInstance->get($hash);
+        } else {
+            $result = $this->getFullConfiguration();
             $result = (ArrayUtility::isValidPath($result, self::EXTENSION_CONFIGURATION_PATH, '.'))
                 ? ArrayUtility::getValueByPath($result, self::EXTENSION_CONFIGURATION_PATH, '.')
                 : [];
 
             if (ArrayUtility::isValidPath($result, 'settings.typoScriptIncluded', '.')) {
-                $hash = 'ts-conf-page-' . sha1(serialize($result));
                 $cacheInstance->set($hash, $result);
-                $this->pagesConfigurationHashes[$pageUid] = $hash;
-                $cacheInstance->set(self::PAGES_CONFIGURATION_HASHES_CACHE_IDENTIFIER, $this->pagesConfigurationHashes);
             }
         }
 
@@ -150,48 +121,43 @@ class TypoScriptUtility implements SingletonInterface
     }
 
     /**
-     * Returns the TypoScript configuration, including the static configuration
-     * from files (see function `getExtensionConfiguration()`).
+     * Returns the full TypoScript configuration, based on the context of the
+     * current request.
      *
-     * As this function does not save the configuration in cache, we advise not
-     * to call it, and prefer using the function `getConfigurationFromPath()`
-     * instead, which has its own caching system.
-     *
-     * It can still be useful to get the whole TypoScript configuration, so the
-     * function remains public, but use with caution!
-     *
-     * @param int|null $pageUid The uid of the page you want the TypoScript configuration from. If `null` is given, the current page uid is used.
-     * @return array The configuration.
+     * @return array
      */
-    public function getConfiguration($pageUid = null)
+    protected function getFullConfiguration()
     {
-        $pageUid = $this->getRealPageUid($pageUid);
+        $contextHash = $this->getContextHash();
 
-        if (!array_key_exists($pageUid, $this->pageConfiguration)) {
+        if (false === array_key_exists($contextHash, $this->configuration)) {
             if ($this->environmentService->isEnvironmentInFrontendMode()) {
                 $typoScriptArray = Core::get()->getPageController()->tmpl->setup;
             } else {
-                // @todo: backend context
-                $typoScriptArray = [];
+                /** @var ConfigurationManager $configurationManager */
+                $configurationManager = Core::get()->getObjectManager()->get(ConfigurationManager::class);
+                $typoScriptArray = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
             }
 
-            $this->pageConfiguration[$pageUid] = $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScriptArray);
+            $this->configuration[$contextHash] = $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScriptArray);
         }
 
-        return $this->pageConfiguration[$pageUid];
+        return $this->configuration[$contextHash];
     }
 
     /**
-     * Determines the real page uid, depending on the type of the parameter.
+     * Returns a unique hash for the context of the current request, depending
+     * on wether the request comes from frontend or backend.
      *
-     * @param  int|null $pageUid The page uid.
-     * @return int|null The real page uid.
+     * @return string
      */
-    private function getRealPageUid($pageUid)
+    protected function getContextHash()
     {
-        return ($pageUid === null)
-            ? Core::get()->getCurrentPageUid()
-            : $pageUid;
+        $hash = ($this->environmentService->isEnvironmentInFrontendMode())
+            ? 'fe-' . Core::get()->getCurrentPageUid()
+            : 'be-' . Core::get()->sanitizeString(GeneralUtility::_GET('M'));
+
+        return 'ts-conf-' . $hash;
     }
 
     /**

--- a/Classes/Validation/Validator/AbstractValidator.php
+++ b/Classes/Validation/Validator/AbstractValidator.php
@@ -13,7 +13,6 @@
 
 namespace Romm\Formz\Validation\Validator;
 
-use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
 use Romm\Formz\Configuration\Form\Field\Validation\Message;
 use Romm\Formz\Core\Core;
 use Romm\Formz\Form\FormInterface;
@@ -176,7 +175,7 @@ abstract class AbstractValidator extends \TYPO3\CMS\Extbase\Validation\Validator
                 $this->getMessage($key, $arguments),
                 $code,
                 [],
-                DataAttributesAssetHandler::getFieldCleanName(AbstractFormValidator::getCurrentValidationName() . ':' . $key)
+                Core::get()->sanitizeString(AbstractFormValidator::getCurrentValidationName() . ':' . $key)
             );
         }
     }

--- a/Classes/ViewHelpers/FieldViewHelper.php
+++ b/Classes/ViewHelpers/FieldViewHelper.php
@@ -13,7 +13,6 @@
 
 namespace Romm\Formz\ViewHelpers;
 
-use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
 use Romm\Formz\Configuration\View\Layouts\Layout;
 use Romm\Formz\Configuration\View\View;
 use Romm\Formz\Core\Core;
@@ -112,7 +111,7 @@ class FieldViewHelper extends AbstractViewHelper implements CompilableInterface
         $templateArguments['fieldName'] = $fieldName;
         $templateArguments['fieldId'] = (true === isset($templateArguments['fieldId']))
             ? $templateArguments['fieldId']
-            : DataAttributesAssetHandler::getFieldCleanName('formz-' . $form->getFormObject()->getName() . '-' . $fieldName);
+            : Core::get()->sanitizeString('formz-' . $form->getFormObject()->getName() . '-' . $fieldName);
 
         $currentView = $renderingContext->getViewHelperVariableContainer()->getView();
 

--- a/Classes/ViewHelpers/FormatMessageViewHelper.php
+++ b/Classes/ViewHelpers/FormatMessageViewHelper.php
@@ -13,8 +13,8 @@
 
 namespace Romm\Formz\ViewHelpers;
 
-use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
 use Romm\Formz\Configuration\Form\Field\Field;
+use Romm\Formz\Core\Core;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Error\Message;
 use TYPO3\CMS\Extbase\Error\Notice;
@@ -114,7 +114,7 @@ class FormatMessageViewHelper extends AbstractViewHelper implements CompilableIn
 
         $fieldId = ($renderingContext->getTemplateVariableContainer()->exists('fieldId'))
             ? $renderingContext->getTemplateVariableContainer()->get('fieldId')
-            : DataAttributesAssetHandler::getFieldCleanName('formz-' . $form->getFormObject()->getName() . '-' . $fieldName);
+            : Core::get()->sanitizeString('formz-' . $form->getFormObject()->getName() . '-' . $fieldName);
 
         $result = str_replace(
             [

--- a/Resources/Public/JavaScript/Form/Formz.Form.js
+++ b/Resources/Public/JavaScript/Form/Formz.Form.js
@@ -123,7 +123,16 @@ Formz.Form = (function () {
              * @returns {HTMLFormElement}
              */
             getElement: function () {
-                return element;
+                var formElements = window.document.getElementsByName(name);
+
+                if (formElements.length === 0) {
+                    Formz.debug(
+                        'Could not get the DOM element for the form "' + name + '"!',
+                        Formz.TYPE_ERROR
+                    )
+                }
+
+                return formElements[0];
             },
 
             getConfiguration: function () {
@@ -198,23 +207,23 @@ Formz.Form = (function () {
 
         /**
          * When a field is validated, the form is entirely checked to see if all
-		 * fields are valid, in which case an attribute is added to the form DOM
-		 * element: `formz-valid`.
-		 *
-		 * Several usages can be found for this: for instance, the submission
-		 * button can be shown only when the form is valid (logical behaviour
-		 * since the submission is canceled whenever an error is found).
+         * fields are valid, in which case an attribute is added to the form DOM
+         * element: `formz-valid`.
+         *
+         * Several usages can be found for this: for instance, the submission
+         * button can be shown only when the form is valid (logical behaviour
+         * since the submission is canceled whenever an error is found).
          */
-        Formz.Form.get(name, function() {
-            var checkFormIsValid = function() {
+        Formz.Form.get(name, function () {
+            var checkFormIsValid = function () {
                 var globalFlag = true;
                 var fieldsNumber = Formz.objectSize(fields);
                 var fieldsChecked = 0;
 
                 /**
                  * Function called every time a field has been checked. When all
-				 * fields have been checked, the form attribute is added or
-				 * removed, depending on if errors were found.
+                 * fields have been checked, the form attribute is added or
+                 * removed, depending on if errors were found.
                  */
                 var checkAllFieldsWereProcessed = function () {
                     if (fieldsNumber === fieldsChecked) {
@@ -228,18 +237,18 @@ Formz.Form = (function () {
 
                 /**
                  * Checks if the given field is valid. There can be several
-				 * steps, for instance depending on if the field was already
-				 * validated.
+                 * steps, for instance depending on if the field was already
+                 * validated.
                  *
                  * @param {Formz.FullField} field
                  */
-                var checkFieldIsValid = function(field) {
+                var checkFieldIsValid = function (field) {
                     var flag = false;
                     fieldsChecked++;
 
                     field.getActivatedValidationRules(function (validationRules) {
                         if (0 === Formz.objectSize(validationRules)) {
-							// If the field does not have any validation rule, it is obviously considered valid.
+                            // If the field does not have any validation rule, it is obviously considered valid.
                             flag = true;
                         } else {
                             if (field.wasValidated()) {
@@ -349,22 +358,15 @@ Formz.Form = (function () {
          * @param {string} configuration
          */
         register: function (name, configuration) {
-            var formElements = window.document.getElementsByName(name);
+            var form = formPrototype({
+                name: name,
+                configuration: configuration
+            });
 
-            if (formElements.length > 0) {
-                var element = formElements[0];
-                var states = {
-                    name: name,
-                    element: element,
-                    configuration: configuration
-                };
-
-                var form = formPrototype(states);
-                formsRepository[name] = Formz.extend(
-                    form,
-                    Formz.Form.SubmissionService.get(name)
-                );
-            }
+            formsRepository[name] = Formz.extend(
+                form,
+                Formz.Form.SubmissionService.get(name)
+            );
         },
 
         /**

--- a/Tests/Unit/AssetHandler/Connector/JavaScriptAssetHandlerConnectorTest.php
+++ b/Tests/Unit/AssetHandler/Connector/JavaScriptAssetHandlerConnectorTest.php
@@ -37,9 +37,9 @@ class JavaScriptAssetHandlerConnectorTest extends AbstractUnitTest
         $assetHandlerFactory = AssetHandlerFactory::get($formObject, $controllerContext);
 
         /** @var PageRenderer|\PHPUnit_Framework_MockObject_MockObject $pageRendererMock */
-        $pageRendererMock = $this->getMock(PageRenderer::class, ['addJsFile']);
+        $pageRendererMock = $this->getMock(PageRenderer::class, ['addJsFooterFile']);
         $pageRendererMock->expects($this->atLeastOnce())
-            ->method('addJsFile')
+            ->method('addJsFooterFile')
             ->willReturnCallback(function () use (&$filesIncluded) {
                 $filesIncluded++;
             });
@@ -60,9 +60,9 @@ class JavaScriptAssetHandlerConnectorTest extends AbstractUnitTest
         $filesIncludedBis = 0;
 
         /** @var PageRenderer|\PHPUnit_Framework_MockObject_MockObject $pageRendererMockBis */
-        $pageRendererMockBis = $this->getMock(PageRenderer::class, ['addJsFile']);
+        $pageRendererMockBis = $this->getMock(PageRenderer::class, ['addJsFooterFile']);
         $pageRendererMockBis->expects($this->atLeastOnce())
-            ->method('addJsFile')
+            ->method('addJsFooterFile')
             ->willReturnCallback(function () use (&$filesIncludedBis) {
                 $filesIncludedBis++;
             });

--- a/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
@@ -77,6 +77,8 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
      */
     public function checkFieldsErrorsDataAttributesDataProvider()
     {
+        $this->setUpFormzCore();
+
         return [
             'defaultSingleErrorCheck'  => [
                 [


### PR DESCRIPTION
Because of a TYPO3 core issue, asset inclusion in the page footer wont work for backend context. This commit will fix it by adding an abstraction function which will handle both frontend and backend context. See this forge issue for more information: https://forge.typo3.org/issues/60213

This commit also resolves #35: the default JavaScript files are now included in the footer (in frontend context), as they already should have.

The JavaScript API changed a bit, it is more flexible to allow the registration of a new form before the DOM has been fully loaded.