### PR TITLE
[TASK] Improve assets inclusion to make it work in backend context

### DIFF
--- a/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
+++ b/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
@@ -96,7 +96,7 @@ class CssAssetHandlerConnector
 
         $this->assetHandlerConnectorManager
             ->getPageRenderer()
-            ->addCssFile($filePath);
+            ->addCssFile(Core::get()->getResourceRelativePath($filePath));
 
         return $this;
     }

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -364,6 +364,10 @@ class Core implements SingletonInterface
     {
         $relativePath = ExtensionManagementUtility::siteRelPath('formz');
 
+        if ($this->environmentService->isEnvironmentInBackendMode()) {
+            $relativePath = '../' . $relativePath;
+        }
+
         return (null !== $path)
             ? $relativePath . $path
             : $relativePath;
@@ -375,13 +379,19 @@ class Core implements SingletonInterface
      */
     public function getResourceRelativePath($path)
     {
-        return rtrim(
+        $relativePath = rtrim(
             PathUtility::getRelativePath(
                 GeneralUtility::getIndpEnv('TYPO3_DOCUMENT_ROOT'),
                 GeneralUtility::getFileAbsFileName($path)
             ),
             '/'
         );
+
+        if ($this->environmentService->isEnvironmentInBackendMode()) {
+            $relativePath = '../' . $relativePath;
+        }
+
+        return $relativePath;
     }
 
     /**

--- a/Resources/Public/JavaScript/Form/Formz.Form.js
+++ b/Resources/Public/JavaScript/Form/Formz.Form.js
@@ -123,7 +123,16 @@ Formz.Form = (function () {
              * @returns {HTMLFormElement}
              */
             getElement: function () {
-                return element;
+                var formElements = window.document.getElementsByName(name);
+
+                if (formElements.length === 0) {
+                    Formz.debug(
+                        'Could not get the DOM element for the form "' + name + '"!',
+                        Formz.TYPE_ERROR
+                    )
+                }
+
+                return formElements[0];
             },
 
             getConfiguration: function () {
@@ -198,23 +207,23 @@ Formz.Form = (function () {
 
         /**
          * When a field is validated, the form is entirely checked to see if all
-		 * fields are valid, in which case an attribute is added to the form DOM
-		 * element: `formz-valid`.
-		 *
-		 * Several usages can be found for this: for instance, the submission
-		 * button can be shown only when the form is valid (logical behaviour
-		 * since the submission is canceled whenever an error is found).
+         * fields are valid, in which case an attribute is added to the form DOM
+         * element: `formz-valid`.
+         *
+         * Several usages can be found for this: for instance, the submission
+         * button can be shown only when the form is valid (logical behaviour
+         * since the submission is canceled whenever an error is found).
          */
-        Formz.Form.get(name, function() {
-            var checkFormIsValid = function() {
+        Formz.Form.get(name, function () {
+            var checkFormIsValid = function () {
                 var globalFlag = true;
                 var fieldsNumber = Formz.objectSize(fields);
                 var fieldsChecked = 0;
 
                 /**
                  * Function called every time a field has been checked. When all
-				 * fields have been checked, the form attribute is added or
-				 * removed, depending on if errors were found.
+                 * fields have been checked, the form attribute is added or
+                 * removed, depending on if errors were found.
                  */
                 var checkAllFieldsWereProcessed = function () {
                     if (fieldsNumber === fieldsChecked) {
@@ -228,18 +237,18 @@ Formz.Form = (function () {
 
                 /**
                  * Checks if the given field is valid. There can be several
-				 * steps, for instance depending on if the field was already
-				 * validated.
+                 * steps, for instance depending on if the field was already
+                 * validated.
                  *
                  * @param {Formz.FullField} field
                  */
-                var checkFieldIsValid = function(field) {
+                var checkFieldIsValid = function (field) {
                     var flag = false;
                     fieldsChecked++;
 
                     field.getActivatedValidationRules(function (validationRules) {
                         if (0 === Formz.objectSize(validationRules)) {
-							// If the field does not have any validation rule, it is obviously considered valid.
+                            // If the field does not have any validation rule, it is obviously considered valid.
                             flag = true;
                         } else {
                             if (field.wasValidated()) {
@@ -349,22 +358,15 @@ Formz.Form = (function () {
          * @param {string} configuration
          */
         register: function (name, configuration) {
-            var formElements = window.document.getElementsByName(name);
+            var form = formPrototype({
+                name: name,
+                configuration: configuration
+            });
 
-            if (formElements.length > 0) {
-                var element = formElements[0];
-                var states = {
-                    name: name,
-                    element: element,
-                    configuration: configuration
-                };
-
-                var form = formPrototype(states);
-                formsRepository[name] = Formz.extend(
-                    form,
-                    Formz.Form.SubmissionService.get(name)
-                );
-            }
+            formsRepository[name] = Formz.extend(
+                form,
+                Formz.Form.SubmissionService.get(name)
+            );
         },
 
         /**

--- a/Tests/Unit/AssetHandler/Connector/JavaScriptAssetHandlerConnectorTest.php
+++ b/Tests/Unit/AssetHandler/Connector/JavaScriptAssetHandlerConnectorTest.php
@@ -37,9 +37,9 @@ class JavaScriptAssetHandlerConnectorTest extends AbstractUnitTest
         $assetHandlerFactory = AssetHandlerFactory::get($formObject, $controllerContext);
 
         /** @var PageRenderer|\PHPUnit_Framework_MockObject_MockObject $pageRendererMock */
-        $pageRendererMock = $this->getMock(PageRenderer::class, ['addJsFile']);
+        $pageRendererMock = $this->getMock(PageRenderer::class, ['addJsFooterFile']);
         $pageRendererMock->expects($this->atLeastOnce())
-            ->method('addJsFile')
+            ->method('addJsFooterFile')
             ->willReturnCallback(function () use (&$filesIncluded) {
                 $filesIncluded++;
             });
@@ -60,9 +60,9 @@ class JavaScriptAssetHandlerConnectorTest extends AbstractUnitTest
         $filesIncludedBis = 0;
 
         /** @var PageRenderer|\PHPUnit_Framework_MockObject_MockObject $pageRendererMockBis */
-        $pageRendererMockBis = $this->getMock(PageRenderer::class, ['addJsFile']);
+        $pageRendererMockBis = $this->getMock(PageRenderer::class, ['addJsFooterFile']);
         $pageRendererMockBis->expects($this->atLeastOnce())
-            ->method('addJsFile')
+            ->method('addJsFooterFile')
             ->willReturnCallback(function () use (&$filesIncludedBis) {
                 $filesIncludedBis++;
             });


### PR DESCRIPTION
Because of a TYPO3 core issue, asset inclusion in the page footer wont work for backend context. This commit will fix it by adding an abstraction function which will handle both frontend and backend context. See this forge issue for more information: https://forge.typo3.org/issues/60213

This commit also resolves #35: the default JavaScript files are now included in the footer (in frontend context), as they already should have.

The JavaScript API changed a bit, it is more flexible to allow the registration of a new form before the DOM has been fully loaded.