### PR TITLE
[FATURE] Handle `warning` and `notice` types in validation messages

### DIFF
--- a/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
+++ b/Classes/AssetHandler/Connector/CssAssetHandlerConnector.php
@@ -13,7 +13,7 @@
 
 namespace Romm\Formz\AssetHandler\Connector;
 
-use Romm\Formz\AssetHandler\Css\ErrorContainerDisplayCssAssetHandler;
+use Romm\Formz\AssetHandler\Css\FeedbackContainerDisplayCssAssetHandler;
 use Romm\Formz\AssetHandler\Css\FieldsActivationCssAssetHandler;
 use Romm\Formz\Service\StringService;
 
@@ -77,10 +77,10 @@ class CssAssetHandlerConnector
         $this->assetHandlerConnectorManager->createFileInTemporaryDirectory(
             $filePath,
             function () {
-                /** @var ErrorContainerDisplayCssAssetHandler $errorContainerDisplayCssAssetHandler */
+                /** @var FeedbackContainerDisplayCssAssetHandler $errorContainerDisplayCssAssetHandler */
                 $errorContainerDisplayCssAssetHandler = $this->assetHandlerConnectorManager
                     ->getAssetHandlerFactory()
-                    ->getAssetHandler(ErrorContainerDisplayCssAssetHandler::class);
+                    ->getAssetHandler(FeedbackContainerDisplayCssAssetHandler::class);
 
                 /** @var FieldsActivationCssAssetHandler $fieldsActivationCssAssetHandler */
                 $fieldsActivationCssAssetHandler = $this->assetHandlerConnectorManager

--- a/Classes/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandler.php
+++ b/Classes/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandler.php
@@ -35,11 +35,13 @@ class FeedbackContainerDisplayCssAssetHandler extends AbstractAssetHandler
 
         foreach ($formConfiguration->getFields() as $fieldName => $field) {
             $formName = $this->getFormObject()->getName();
-            $errorSelector = DataAttributesAssetHandler::getFieldDataMessageKey($fieldName);
+            $errorSelector = DataAttributesAssetHandler::getFieldDataMessageKey($fieldName, 'error');
+            $warningSelector = DataAttributesAssetHandler::getFieldDataMessageKey($fieldName, 'warning');
+            $noticeSelector = DataAttributesAssetHandler::getFieldDataMessageKey($fieldName, 'notice');
             $errorContainerCss = $field->getSettings()->getFeedbackContainerSelector();
 
             $cssBlocks[] = <<<CSS
-form[name="$formName"]:not([$errorSelector="1"]) $errorContainerCss {
+form[name="$formName"]:not([$errorSelector="1"]):not([$warningSelector="1"]):not([$noticeSelector="1"]) $errorContainerCss {
     display: none!important;
 }
 CSS;

--- a/Classes/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandler.php
+++ b/Classes/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandler.php
@@ -20,7 +20,7 @@ use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
  * This asset handler generates the CSS code which will automatically hide the
  * error container of the fields when they have no errors.
  */
-class ErrorContainerDisplayCssAssetHandler extends AbstractAssetHandler
+class FeedbackContainerDisplayCssAssetHandler extends AbstractAssetHandler
 {
 
     /**
@@ -35,7 +35,7 @@ class ErrorContainerDisplayCssAssetHandler extends AbstractAssetHandler
 
         foreach ($formConfiguration->getFields() as $fieldName => $field) {
             $formName = $this->getFormObject()->getName();
-            $errorSelector = DataAttributesAssetHandler::getFieldDataErrorKey($fieldName);
+            $errorSelector = DataAttributesAssetHandler::getFieldDataMessageKey($fieldName);
             $errorContainerCss = $field->getSettings()->getFeedbackContainerSelector();
 
             $cssBlocks[] = <<<CSS

--- a/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
+++ b/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
@@ -15,8 +15,8 @@ namespace Romm\Formz\AssetHandler\Html;
 
 use Romm\Formz\AssetHandler\AbstractAssetHandler;
 use Romm\Formz\Error\FormResult;
+use Romm\Formz\Error\FormzMessageInterface;
 use Romm\Formz\Form\FormInterface;
-use Romm\Formz\Service\MessageService;
 use Romm\Formz\Service\StringService;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
@@ -132,9 +132,9 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
     }
 
     /**
-     * @param string $fieldName
-     * @param array  $messages
-     * @param string $type
+     * @param string                  $fieldName
+     * @param FormzMessageInterface[] $messages
+     * @param string                  $type
      * @return array
      */
     protected function addFieldMessageDataAttribute($fieldName, array $messages, $type)
@@ -142,8 +142,8 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
         $result = [self::getFieldDataMessageKey($fieldName, $type) => '1'];
 
         foreach ($messages as $message) {
-            $validationName = MessageService::get()->getMessageValidationName($message);
-            $messageKey = MessageService::get()->getMessageKey($message);
+            $validationName = $message->getValidationName();
+            $messageKey = $message->getMessageKey();
 
             $result[self::getFieldDataValidationMessageKey($fieldName, $type, $validationName, $messageKey)] = '1';
         }

--- a/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
+++ b/Classes/AssetHandler/Html/DataAttributesAssetHandler.php
@@ -18,7 +18,6 @@ use Romm\Formz\Error\FormResult;
 use Romm\Formz\Form\FormInterface;
 use Romm\Formz\Service\MessageService;
 use Romm\Formz\Service\StringService;
-use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 /**
@@ -33,6 +32,7 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
  *    validation rules), the form gets the attribute: `formz-valid-{field name}`.
  *  - Fields errors: when a field validation fails with an error, the form gets
  *    the attribute: `formz-error-{field name}-{name of the error}`.
+ *  - Fields warnings and notices: same as errors.
  */
 class DataAttributesAssetHandler extends AbstractAssetHandler
 {
@@ -95,7 +95,8 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
     }
 
     /**
-     * Handles the data attributes for the fields which got errors.
+     * Handles the data attributes for the fields which got errors, warnings and
+     * notices.
      *
      * Examples:
      * - `formz-error-email="1"`
@@ -104,26 +105,47 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
      * @param FormResult $requestResult
      * @return array
      */
-    public function getFieldsErrorsDataAttributes(FormResult $requestResult)
+    public function getFieldsMessagesDataAttributes(FormResult $requestResult)
     {
         $result = [];
         $formConfiguration = $this->getFormObject()->getConfiguration();
 
-        /** @var Result $fieldResult */
         foreach ($requestResult->getSubResults() as $fieldName => $fieldResult) {
-            if (true === $fieldResult->hasErrors()
-                && true === $formConfiguration->hasField($fieldName)
+            if (true === $formConfiguration->hasField($fieldName)
                 && false === $requestResult->fieldIsDeactivated($formConfiguration->getField($fieldName))
             ) {
-                $result[self::getFieldDataErrorKey($fieldName)] = '1';
+                if (true === $fieldResult->hasErrors()) {
+                    $result += $this->addFieldMessageDataAttribute($fieldName, $fieldResult->getErrors(), 'error');
+                }
 
-                foreach ($fieldResult->getErrors() as $error) {
-                    $validationName = MessageService::get()->getMessageValidationName($error);
-                    $messageKey = MessageService::get()->getMessageKey($error);
+                if (true === $fieldResult->hasWarnings()) {
+                    $result += $this->addFieldMessageDataAttribute($fieldName, $fieldResult->getWarnings(), 'warning');
+                }
 
-                    $result[self::getFieldDataValidationErrorKey($fieldName, $validationName, $messageKey)] = '1';
+                if (true === $fieldResult->hasNotices()) {
+                    $result += $this->addFieldMessageDataAttribute($fieldName, $fieldResult->getNotices(), 'notice');
                 }
             }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $fieldName
+     * @param array  $messages
+     * @param string $type
+     * @return array
+     */
+    protected function addFieldMessageDataAttribute($fieldName, array $messages, $type)
+    {
+        $result = [self::getFieldDataMessageKey($fieldName, $type) => '1'];
+
+        foreach ($messages as $message) {
+            $validationName = MessageService::get()->getMessageValidationName($message);
+            $messageKey = MessageService::get()->getMessageKey($message);
+
+            $result[self::getFieldDataValidationMessageKey($fieldName, $type, $validationName, $messageKey)] = '1';
         }
 
         return $result;
@@ -178,32 +200,35 @@ class DataAttributesAssetHandler extends AbstractAssetHandler
     }
 
     /**
-     * Formats the data error attribute key for a given field name.
+     * Formats the data message attribute key for a given field name.
      *
      * @param string $fieldName Name of the field.
+     * @param string $type      Type of the message: `error`, `warning` or `notice`.
      * @return string
      */
-    public static function getFieldDataErrorKey($fieldName)
+    public static function getFieldDataMessageKey($fieldName, $type = 'error')
     {
-        return 'formz-error-' . StringService::get()->sanitizeString($fieldName);
+        return 'formz-' . $type . '-' . StringService::get()->sanitizeString($fieldName);
     }
 
     /**
-     * Formats the data error attribute key for a given failed validation for
+     * Formats the data message attribute key for a given failed validation for
      * the given field name.
      *
      * @param string $fieldName
+     * @param string $type Type of the message: `error`, `warning` or `notice`.
      * @param string $validationName
      * @param string $messageKey
      * @return string
      */
-    public static function getFieldDataValidationErrorKey($fieldName, $validationName, $messageKey)
+    public static function getFieldDataValidationMessageKey($fieldName, $type, $validationName, $messageKey)
     {
         $stringService = StringService::get();
 
         return vsprintf(
-            'formz-error-%s-%s-%s',
+            'formz-%s-%s-%s-%s',
             [
+                $type,
                 $stringService->sanitizeString($fieldName),
                 $stringService->sanitizeString($validationName),
                 $stringService->sanitizeString($messageKey)

--- a/Classes/Condition/Items/FieldHasErrorCondition.php
+++ b/Classes/Condition/Items/FieldHasErrorCondition.php
@@ -61,7 +61,7 @@ class FieldHasErrorCondition extends AbstractConditionItem
     {
         return sprintf(
             '[%s="1"]',
-            DataAttributesAssetHandler::getFieldDataValidationErrorKey($this->fieldName, $this->validationName, $this->errorName)
+            DataAttributesAssetHandler::getFieldDataValidationMessageKey($this->fieldName, 'error', $this->validationName, $this->errorName)
         );
     }
 

--- a/Classes/Controller/AjaxValidationController.php
+++ b/Classes/Controller/AjaxValidationController.php
@@ -24,8 +24,10 @@ use Romm\Formz\Form\FormObject;
 use Romm\Formz\Form\FormObjectFactory;
 use Romm\Formz\Service\ContextService;
 use Romm\Formz\Service\ExtensionService;
+use Romm\Formz\Service\MessageService;
 use Romm\Formz\Validation\DataObject\ValidatorDataObject;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Error\Message;
 use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\View\JsonView;
@@ -152,7 +154,9 @@ class AjaxValidationController extends ActionController
         // Default technical error result if the function can not be reached.
         $result = [
             'success' => false,
-            'message' => [ContextService::get()->translate(self::DEFAULT_ERROR_MESSAGE_KEY)]
+            'messages' => [
+                'errors' => ['default' => ContextService::get()->translate(self::DEFAULT_ERROR_MESSAGE_KEY)]
+            ]
         ];
 
         // We prevent any external message to be displayed here.
@@ -164,7 +168,7 @@ class AjaxValidationController extends ActionController
             $result['data'] = ['errorCode' => $exception->getCode()];
 
             if (ExtensionService::get()->isInDebugMode()) {
-                $result['message'] = $this->getDebugMessageForException($exception);
+                $result['messages']['errors']['default'] = $this->getDebugMessageForException($exception);
             }
         }
 
@@ -322,14 +326,40 @@ class AjaxValidationController extends ActionController
      */
     protected function convertResultToJson(Result $result)
     {
-        $error = ($result->hasErrors())
-            ? $result->getFirstError()->getMessage()
-            : '';
+        $messages = [];
+
+        if ($result->hasErrors()) {
+            $messages['errors'] = $this->formatMessages($result->getErrors());
+        }
+
+        if ($result->hasWarnings()) {
+            $messages['warnings'] = $this->formatMessages($result->getWarnings());
+        }
+
+        if ($result->hasNotices()) {
+            $messages['notices'] = $this->formatMessages($result->getNotices());
+        }
 
         return [
             'success' => !$result->hasErrors(),
-            'message' => $error
+            'messages' => $messages
         ];
+    }
+
+    /**
+     * @param Message[] $messages
+     * @return array
+     */
+    protected function formatMessages(array $messages)
+    {
+        $sortedMessages = [];
+
+        foreach ($messages as $message) {
+            $key = MessageService::get()->getMessageKey($message);
+            $sortedMessages[$key] = $message->getMessage();
+        }
+
+        return $sortedMessages;
     }
 
     /**

--- a/Classes/Error/FormResult.php
+++ b/Classes/Error/FormResult.php
@@ -27,12 +27,12 @@ class FormResult extends Result
     use StoreDataTrait;
 
     /**
-     * @var array
+     * @var Field[]
      */
     protected $deactivatedFields = [];
 
     /**
-     * @var array
+     * @var Validation[]
      */
     protected $deactivatedFieldsValidation = [];
 
@@ -43,7 +43,7 @@ class FormResult extends Result
      */
     public function deactivateField(Field $field)
     {
-        $this->deactivatedFields[$field->getFieldName()] = true;
+        $this->deactivatedFields[$field->getFieldName()] = $field;
     }
 
     /**
@@ -58,6 +58,14 @@ class FormResult extends Result
     }
 
     /**
+     * @return Field[]
+     */
+    public function getDeactivatedFields()
+    {
+        return $this->deactivatedFields;
+    }
+
+    /**
      * @param Validation $validation
      */
     public function deactivateValidation(Validation $validation)
@@ -68,7 +76,7 @@ class FormResult extends Result
             $this->deactivatedFieldsValidation[$fieldName] = [];
         }
 
-        $this->deactivatedFieldsValidation[$fieldName][$validation->getValidationName()] = true;
+        $this->deactivatedFieldsValidation[$fieldName][$validation->getValidationName()] = $validation;
     }
 
     /**
@@ -81,5 +89,13 @@ class FormResult extends Result
 
         return array_key_exists($fieldName, $this->deactivatedFieldsValidation)
             && array_key_exists($validation->getValidationName(), $this->deactivatedFieldsValidation[$fieldName]);
+    }
+
+    /**
+     * @return Validation[]
+     */
+    public function getDeactivatedValidations()
+    {
+        return $this->deactivatedFieldsValidation;
     }
 }

--- a/Classes/Form/FormObject.php
+++ b/Classes/Form/FormObject.php
@@ -18,6 +18,7 @@ use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use Romm\Formz\Configuration\ConfigurationFactory;
 use Romm\Formz\Configuration\Form\Form;
 use Romm\Formz\Core\Core;
+use Romm\Formz\Error\FormResult;
 use Romm\Formz\Service\CacheService;
 use TYPO3\CMS\Extbase\Error\Result;
 
@@ -71,6 +72,11 @@ class FormObject
      * @var Result
      */
     protected $configurationValidationResult;
+
+    /**
+     * @var FormResult
+     */
+    protected $lastValidationResult;
 
     /**
      * @var string
@@ -306,6 +312,30 @@ class FormObject
     public function injectConfigurationFactory(ConfigurationFactory $configurationFactory)
     {
         $this->configurationFactory = $configurationFactory;
+    }
+
+    /**
+     * @return FormResult
+     */
+    public function getLastValidationResult()
+    {
+        return $this->lastValidationResult;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLastValidationResult()
+    {
+        return null !== $this->lastValidationResult;
+    }
+
+    /**
+     * @param FormResult $lastValidationResult
+     */
+    public function setLastValidationResult($lastValidationResult)
+    {
+        $this->lastValidationResult = $lastValidationResult;
     }
 
     /**

--- a/Classes/Service/MessageService.php
+++ b/Classes/Service/MessageService.php
@@ -31,6 +31,11 @@ class MessageService implements SingletonInterface
     protected $signalSlotDispatcher;
 
     /**
+     * @var int
+     */
+    protected $unknownCount = 0;
+
+    /**
      * Returns the validation name of a message: if it is an instance of
      * `FormzMessageInterface`, we can fetch it, otherwise `unknown` is
      * returned.
@@ -42,7 +47,7 @@ class MessageService implements SingletonInterface
     {
         return ($message instanceof FormzMessageInterface)
             ? $message->getValidationName()
-            : 'unknown';
+            : 'unknown-' . $this->unknownCount++;
     }
 
     /**
@@ -57,7 +62,7 @@ class MessageService implements SingletonInterface
     {
         return ($message instanceof FormzMessageInterface)
             ? $message->getMessageKey()
-            : 'unknown';
+            : 'unknown-' . $this->unknownCount++;
     }
 
     /**

--- a/Classes/Service/MessageService.php
+++ b/Classes/Service/MessageService.php
@@ -14,11 +14,13 @@
 namespace Romm\Formz\Service;
 
 use Romm\Formz\Configuration\Form\Field\Validation\Message as FormzMessage;
+use Romm\Formz\Configuration\Form\Field\Validation\Validation;
 use Romm\Formz\Error\FormzMessageInterface;
 use Romm\Formz\Service\Traits\ExtendedFacadeInstanceTrait;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Error\Message;
+use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
 class MessageService implements SingletonInterface
@@ -31,43 +33,58 @@ class MessageService implements SingletonInterface
     protected $signalSlotDispatcher;
 
     /**
-     * @var int
-     */
-    protected $unknownValidationCount = 0;
-
-    /**
-     * @var int
-     */
-    protected $unknownKeyCount = 0;
-
-    /**
-     * Returns the validation name of a message: if it is an instance of
-     * `FormzMessageInterface`, we can fetch it, otherwise `unknown` is
-     * returned.
+     * This function will go through all errors, warnings and notices and check
+     * if they are instances of `FormzMessageInterface`. If not, they are
+     * converted in order to have more informations that are needed later.
      *
-     * @param Message $message
-     * @return string
+     * @param Result     $result
+     * @param Validation $validation
+     * @return Result
      */
-    public function getMessageValidationName(Message $message)
+    public function sanitizeValidatorResult(Result $result, Validation $validation)
     {
-        return ($message instanceof FormzMessageInterface)
-            ? $message->getValidationName()
-            : 'unknown-' . $this->unknownValidationCount++;
+        $newResult = new Result;
+
+        $this->sanitizeValidatorResultMessages('error', $result->getFlattenedErrors(), $newResult, $validation);
+        $this->sanitizeValidatorResultMessages('warning', $result->getFlattenedWarnings(), $newResult, $validation);
+        $this->sanitizeValidatorResultMessages('notice', $result->getFlattenedNotices(), $newResult, $validation);
+
+        return $newResult;
     }
 
     /**
-     * Returns the key of a message: if it is an instance of
-     * `FormzMessageInterface`, we can fetch it, otherwise `unknown` is
-     * returned.
-     *
-     * @param Message $message
-     * @return string
+     * @param string     $type
+     * @param array      $messages
+     * @param Result     $newResult
+     * @param Validation $validation
      */
-    public function getMessageKey(Message $message)
+    protected function sanitizeValidatorResultMessages($type, array $messages, Result $newResult, Validation $validation)
     {
-        return ($message instanceof FormzMessageInterface)
-            ? $message->getMessageKey()
-            : 'unknown-' . $this->unknownKeyCount++;
+        $addMethod = 'add' . ucfirst($type);
+        $objectType = 'Romm\\Formz\\Error\\' . ucfirst($type);
+        $unknownCounter = 0;
+
+        /** @var Message[] $messagesList */
+        foreach ($messages as $path => $messagesList) {
+            foreach ($messagesList as $message) {
+                if (false === $message instanceof FormzMessageInterface) {
+                    $message = new $objectType(
+                        $message->getMessage(),
+                        $message->getCode(),
+                        $validation->getValidationName(),
+                        'unknown-' . ++$unknownCounter,
+                        $message->getArguments(),
+                        $message->getTitle()
+                    );
+                }
+
+                if (empty($path)) {
+                    $newResult->$addMethod($message);
+                } else {
+                    $newResult->forProperty($path)->$addMethod($message);
+                }
+            }
+        }
     }
 
     /**

--- a/Classes/Service/MessageService.php
+++ b/Classes/Service/MessageService.php
@@ -33,7 +33,12 @@ class MessageService implements SingletonInterface
     /**
      * @var int
      */
-    protected $unknownCount = 0;
+    protected $unknownValidationCount = 0;
+
+    /**
+     * @var int
+     */
+    protected $unknownKeyCount = 0;
 
     /**
      * Returns the validation name of a message: if it is an instance of
@@ -47,7 +52,7 @@ class MessageService implements SingletonInterface
     {
         return ($message instanceof FormzMessageInterface)
             ? $message->getValidationName()
-            : 'unknown-' . $this->unknownCount++;
+            : 'unknown-' . $this->unknownValidationCount++;
     }
 
     /**
@@ -62,7 +67,7 @@ class MessageService implements SingletonInterface
     {
         return ($message instanceof FormzMessageInterface)
             ? $message->getMessageKey()
-            : 'unknown-' . $this->unknownCount++;
+            : 'unknown-' . $this->unknownKeyCount++;
     }
 
     /**

--- a/Classes/Validation/Validator/Form/AbstractFormValidator.php
+++ b/Classes/Validation/Validator/Form/AbstractFormValidator.php
@@ -82,19 +82,6 @@ abstract class AbstractFormValidator extends ExtbaseAbstractValidator implements
     protected $result;
 
     /**
-     * Contains the validation results of all forms which were validated. The
-     * key is the form name (the property `formName` in the form configuration)
-     * and the value is an instance of `FormResult`.
-     *
-     * Note: we need to store the results here, because the TYPO3 request
-     * handler builds an instance of Extbase's `Result` from scratch, so we are
-     * not able to retrieve the `FormResult` instance afterward.
-     *
-     * @var FormResult[]
-     */
-    private static $formsValidationResults = [];
-
-    /**
      * Checks the given form instance, and launches the validation if it is a
      * correct form.
      *
@@ -142,7 +129,7 @@ abstract class AbstractFormValidator extends ExtbaseAbstractValidator implements
             FormService::addFormWithErrors($form);
         }
 
-        self::$formsValidationResults[get_class($form) . '::' . $this->options['name']] = $this->result;
+        $formValidatorExecutor->saveValidationResult();
     }
 
     /**
@@ -176,23 +163,6 @@ abstract class AbstractFormValidator extends ExtbaseAbstractValidator implements
         if (method_exists($this, $functionName)) {
             call_user_func([$this, $functionName]);
         }
-    }
-
-    /**
-     * Returns the validation result of the asked form. The form name matches
-     * the property `formName` of the form configuration.
-     *
-     * @param string $formClassName
-     * @param string $formName
-     * @return null|FormResult
-     */
-    public static function getFormValidationResult($formClassName, $formName)
-    {
-        $key = $formClassName . '::' . $formName;
-
-        return (true === isset(self::$formsValidationResults[$key]))
-            ? self::$formsValidationResults[$key]
-            : null;
     }
 
     /**

--- a/Classes/Validation/Validator/Form/FormValidatorExecutor.php
+++ b/Classes/Validation/Validator/Form/FormValidatorExecutor.php
@@ -24,6 +24,7 @@ use Romm\Formz\Error\FormResult;
 use Romm\Formz\Form\FormInterface;
 use Romm\Formz\Form\FormObject;
 use Romm\Formz\Form\FormObjectFactory;
+use Romm\Formz\Service\MessageService;
 use Romm\Formz\Validation\DataObject\ValidatorDataObject;
 use Romm\Formz\Validation\Validator\AbstractValidator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -219,6 +220,16 @@ class FormValidatorExecutor
     }
 
     /**
+     * Will save the validation result in the form object instance.
+     *
+     * @internal
+     */
+    public function saveValidationResult()
+    {
+        $this->getFormObject()->setLastValidationResult($this->result);
+    }
+
+    /**
      * @param Field      $field
      * @param Validation $validation
      * @return Result
@@ -237,6 +248,7 @@ class FormValidatorExecutor
         );
 
         $validatorResult = $validator->validate($fieldValue);
+        $validatorResult = MessageService::get()->sanitizeValidatorResult($validatorResult, $validation);
 
         if ($validator instanceof AbstractValidator
             && false === empty($validationData = $validator->getValidationData())

--- a/Classes/ViewHelpers/ClassViewHelper.php
+++ b/Classes/ViewHelpers/ClassViewHelper.php
@@ -221,7 +221,16 @@ class ClassViewHelper extends AbstractViewHelper
                 }
                 break;
             case self::CLASS_VALID:
-                if (false === $propertyResult->hasErrors()) {
+                $formObject = $this->formService->getFormObject();
+                $field = $formObject->getConfiguration()->getField($this->fieldName);
+
+                if (false === $propertyResult->hasErrors()
+                    && false === $formObject->hasLastValidationResult()
+                    || (
+                        $formObject->hasLastValidationResult()
+                        && false === $formObject->getLastValidationResult()->fieldIsDeactivated($field)
+                    )
+                ) {
                     $result .= ' ' . $this->classValue;
                 }
                 break;

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -24,7 +24,6 @@ use Romm\Formz\Service\ContextService;
 use Romm\Formz\Service\ExtensionService;
 use Romm\Formz\Service\StringService;
 use Romm\Formz\Service\TimeTrackerService;
-use Romm\Formz\Validation\Validator\Form\AbstractFormValidator;
 use Romm\Formz\Validation\Validator\Form\DefaultFormValidator;
 use Romm\Formz\ViewHelpers\Service\FormService;
 use TYPO3\CMS\Core\Page\PageRenderer;
@@ -231,13 +230,8 @@ class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
             /** @var array $formInstance */
             $formInstance = $originalRequest->getArgument($this->getFormObjectName());
 
-            $formRequestResult = AbstractFormValidator::getFormValidationResult(
-                $this->getFormObjectClassName(),
-                $this->getFormObjectName()
-            );
-
             $this->formService->setFormInstance($formInstance);
-            $this->formService->setFormResult($formRequestResult);
+            $this->formService->setFormResult($this->formService->getFormObject()->getLastValidationResult());
             $this->formService->markFormAsSubmitted();
         } elseif (null !== $this->arguments['object']) {
             $formInstance = $this->arguments['object'];

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -338,7 +338,7 @@ class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
 
             if (true === $this->formService->formWasSubmitted()) {
                 $dataAttributes += ['formz-submission-done' => '1'];
-                $dataAttributes += $dataAttributesAssetHandler->getFieldsErrorsDataAttributes($formResult);
+                $dataAttributes += $dataAttributesAssetHandler->getFieldsMessagesDataAttributes($formResult);
             }
         }
 

--- a/Classes/ViewHelpers/FormatMessageViewHelper.php
+++ b/Classes/ViewHelpers/FormatMessageViewHelper.php
@@ -18,7 +18,6 @@ use Romm\Formz\Error\FormzMessageInterface;
 use Romm\Formz\Exceptions\EntryNotFoundException;
 use Romm\Formz\Exceptions\InvalidArgumentTypeException;
 use Romm\Formz\Exceptions\InvalidEntryException;
-use Romm\Formz\Service\MessageService;
 use Romm\Formz\Service\StringService;
 use Romm\Formz\ViewHelpers\Service\FieldService;
 use Romm\Formz\ViewHelpers\Service\FormService;
@@ -95,8 +94,8 @@ class FormatMessageViewHelper extends AbstractViewHelper
                 $fieldName,
                 $fieldId,
                 $this->getMessageType($message),
-                MessageService::get()->getMessageValidationName($message),
-                MessageService::get()->getMessageKey($message),
+                $message->getValidationName(),
+                $message->getMessageKey(),
                 $message->getMessage()
             ],
             $field->getSettings()->getMessageTemplate()
@@ -113,9 +112,9 @@ class FormatMessageViewHelper extends AbstractViewHelper
     {
         $message = $this->arguments['message'];
 
-        if (false === $message instanceof Message) {
+        if (false === $message instanceof FormzMessageInterface) {
             throw new InvalidArgumentTypeException(
-                'The argument "message" for the view helper "' . __CLASS__ . '" must be an instance of "' . Message::class . '".',
+                'The argument "message" for the view helper "' . __CLASS__ . '" must be an instance of "' . FormzMessageInterface::class . '".',
                 1467021406
             );
         }
@@ -124,10 +123,10 @@ class FormatMessageViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param Message $message
+     * @param FormzMessageInterface $message
      * @return string
      */
-    protected function getMessageType(Message $message)
+    protected function getMessageType(FormzMessageInterface $message)
     {
         if ($message instanceof Error) {
             $messageType = 'error';

--- a/Configuration/TypoScript/View/Bootstrap/Bootstrap3/setup.txt
+++ b/Configuration/TypoScript/View/Bootstrap/Bootstrap3/setup.txt
@@ -1,4 +1,10 @@
 config.tx_formz {
+    settings {
+        defaultFieldSettings {
+            messageTemplate = <p class="js-validation-rule-#VALIDATOR# js-validation-type-#TYPE# js-validation-message-#KEY#">#MESSAGE#</p>
+        }
+    }
+
     view {
         classes {
             valid {

--- a/Configuration/TypoScript/View/Foundation/Foundation5/setup.txt
+++ b/Configuration/TypoScript/View/Foundation/Foundation5/setup.txt
@@ -1,5 +1,9 @@
 config.tx_formz {
-    settings.defaultFieldSettings.messageTemplate = <small class="#TYPE#">#MESSAGE#</small>
+    settings {
+        defaultFieldSettings {
+            messageTemplate = <small class="#TYPE# js-validation-rule-#VALIDATOR# js-validation-message-#KEY#">#MESSAGE#</small>
+        }
+    }
 
     view {
         classes {

--- a/Resources/Private/Templates/Bootstrap/Default.html
+++ b/Resources/Private/Templates/Bootstrap/Default.html
@@ -5,35 +5,53 @@
 <f:layout name="{layout}" />
 
 <f:section name="Label">
-	<formz:renderSection section="Label.Before" />
+    <formz:renderSection section="Label.Before" />
 
-	<label class="control-label" for="{fieldId}">{label}</label>
+    <label class="control-label" for="{fieldId}">{label}</label>
 
-	<formz:renderSection section="Label.After" />
+    <formz:renderSection section="Label.After" />
 </f:section>
 
 <f:section name="Field">
-	<formz:renderSection section="Field" />
+    <formz:renderSection section="Field" />
 </f:section>
 
 <f:section name="Feedback">
-	<formz:renderSection section="Feedback.Out.Before" />
+    <formz:renderSection section="Feedback.Out.Before" />
 
-	<span class="help-block" formz-field-feedback-container="{fieldName}">
+    <span class="help-block" formz-field-feedback-container="{fieldName}">
 		<formz:renderSection section="Feedback.In.Before" />
 
 		<span formz-field-feedback-list="{fieldName}">
 			<f:form.validationResults for="{formName}.{fieldName}">
-				<f:for each="{validationResults.errors}" as="error">
-					<formz:formatMessage message="{error}" />
-				</f:for>
-			</f:form.validationResults>
+				<f:if condition="{validationResults.errors}">
+					<div class="text-error">
+						<f:for each="{validationResults.errors}" as="error">
+							<formz:formatMessage message="{error}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.warnings}">
+					<div class="text-warning">
+						<f:for each="{validationResults.warnings}" as="warning">
+							<formz:formatMessage message="{warning}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.notices}">
+					<div class="text-info">
+						<f:for each="{validationResults.notices}" as="notice">
+							<formz:formatMessage message="{notice}" />
+						</f:for>
+					</div>
+				</f:if>
+            </f:form.validationResults>
 		</span>
 
 		<formz:renderSection section="Feedback.In.After" />
 	</span>
 
-	<formz:renderSection section="Feedback.Out.After" />
+    <formz:renderSection section="Feedback.Out.After" />
 </f:section>
 
 </html>

--- a/Resources/Private/Templates/Default/Default.html
+++ b/Resources/Private/Templates/Default/Default.html
@@ -20,9 +20,27 @@
 
 		<div formz-field-feedback-list="{fieldName}">
             <f:form.validationResults for="{formName}.{fieldName}">
-                <f:for each="{validationResults.errors}" as="error">
-                    <formz:formatMessage message="{error}" />
-                </f:for>
+				<f:if condition="{validationResults.errors}">
+					<div class="error">
+						<f:for each="{validationResults.errors}" as="error">
+							<formz:formatMessage message="{error}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.warnings}">
+					<div class="warning">
+						<f:for each="{validationResults.warnings}" as="warning">
+							<formz:formatMessage message="{warning}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.notices}">
+					<div class="info">
+						<f:for each="{validationResults.notices}" as="notice">
+							<formz:formatMessage message="{notice}" />
+						</f:for>
+					</div>
+				</f:if>
             </f:form.validationResults>
 		</div>
 

--- a/Resources/Private/Templates/Foundation/Foundation5/Default.html
+++ b/Resources/Private/Templates/Foundation/Foundation5/Default.html
@@ -26,9 +26,27 @@
 	<div formz-field-feedback-container="{fieldName}">
 		<div formz-field-feedback-list="{fieldName}">
 			<f:form.validationResults for="{formName}.{fieldName}">
-				<f:for each="{validationResults.errors}" as="error">
-					<formz:formatMessage message="{error}" />
-				</f:for>
+				<f:if condition="{validationResults.errors}">
+					<div class="error">
+						<f:for each="{validationResults.errors}" as="error">
+							<formz:formatMessage message="{error}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.warnings}">
+					<div class="warning">
+						<f:for each="{validationResults.warnings}" as="warning">
+							<formz:formatMessage message="{warning}" />
+						</f:for>
+					</div>
+				</f:if>
+				<f:if condition="{validationResults.notices}">
+					<div class="info">
+						<f:for each="{validationResults.notices}" as="notice">
+							<formz:formatMessage message="{notice}" />
+						</f:for>
+					</div>
+				</f:if>
 			</f:form.validationResults>
 		</div>
 

--- a/Resources/Public/JavaScript/Conditions/Formz.Condition.FieldHasValue.js
+++ b/Resources/Public/JavaScript/Conditions/Formz.Condition.FieldHasValue.js
@@ -13,10 +13,14 @@ Formz.Condition.registerCondition(
 
 		if (null !== field) {
 			if (value !== '') {
-				flag = (Formz.commaSeparatedValues(field.getValue()).search(value) > -1)
-			} else {
+			    var fieldValue = field.getValue();
+
+                flag = (typeof fieldValue === 'string')
+                    ? fieldValue === value
+                    : (Formz.commaSeparatedValues(fieldValue).search(value) > -1);
+            } else {
 				flag = (Formz.commaSeparatedValues(field.getValue()) == '')
-			}
+            }
 		}
 
 		return flag;

--- a/Resources/Public/JavaScript/Field/Formz.Field.DataAttributesService.js
+++ b/Resources/Public/JavaScript/Field/Formz.Field.DataAttributesService.js
@@ -13,7 +13,11 @@ Formz.Field.DataAttributesService = (function () {
             valid: 'formz-valid-' + Formz.camelCaseToDashed(field.getName()),
             value: 'formz-value-' + Formz.camelCaseToDashed(field.getName()),
             error: 'formz-error-' + Formz.camelCaseToDashed(field.getName()),
+            warning: 'formz-warning-' + Formz.camelCaseToDashed(field.getName()),
+            notice: 'formz-notice-' + Formz.camelCaseToDashed(field.getName()),
             errors: [],
+            warnings: [],
+            notices: [],
             save: {}
         };
 
@@ -46,45 +50,58 @@ Formz.Field.DataAttributesService = (function () {
                 field.getForm().getElement().removeAttribute(dataAttributesNames.value);
             },
 
-            removeErrorsDataAttributes: function () {
+            removeMessagesDataAttributes: function () {
                 field.getForm().getElement().removeAttribute(dataAttributesNames.error);
+                field.getForm().getElement().removeAttribute(dataAttributesNames.warning);
+                field.getForm().getElement().removeAttribute(dataAttributesNames.notice);
 
                 for (var i = 0; i < dataAttributesNames.errors.length; i++) {
                     field.getForm().getElement().removeAttribute(dataAttributesNames.errors[i]);
                 }
+                for (i = 0; i < dataAttributesNames.warnings.length; i++) {
+                    field.getForm().getElement().removeAttribute(dataAttributesNames.warnings[i]);
+                }
+                for (i = 0; i < dataAttributesNames.notices.length; i++) {
+                    field.getForm().getElement().removeAttribute(dataAttributesNames.notices[i]);
+                }
             },
 
-            addErrorsDataAttributes: function (errors) {
-                dataAttributesNames.errors = [];
+            addMessagesDataAttributes: function (messages, type) {
+                var listKey = type + 's';
+                dataAttributesNames[listKey] = [];
 
-                for (var errorName in errors) {
-                    if (errors.hasOwnProperty(errorName)) {
-                        for (var errorMessageKey in errors[errorName]) {
-                            if (errors[errorName].hasOwnProperty(errorMessageKey)) {
-                                var dataErrorName = Formz.Field.DataAttributesService.getFieldErrorDataName(field, errorName, errorMessageKey);
-                                dataAttributesNames.errors.push(dataErrorName);
+                for (var name in messages) {
+                    if (messages.hasOwnProperty(name)) {
+                        for (var key in messages[name]) {
+                            if (messages[name].hasOwnProperty(key)) {
+                                var dataMessageName = Formz.Field.DataAttributesService.getFieldMessageDataName(field, type, name, key);
+                                dataAttributesNames[listKey].push(dataMessageName);
                             }
                         }
                     }
                 }
 
-                this.refreshErrorsDataAttributes();
+                this.refreshMessagesDataAttributes(type);
             },
 
-            refreshErrorsDataAttributes: function () {
-                if (dataAttributesNames.errors.length > 0) {
-                    field.getForm().getElement().setAttribute(dataAttributesNames.error, '1');
+            refreshMessagesDataAttributes: function (type) {
+                var listKey = type + 's';
+
+                if (dataAttributesNames[listKey].length > 0) {
+                    field.getForm().getElement().setAttribute(dataAttributesNames[type], '1');
                 }
 
-                for (var i = 0; i < dataAttributesNames.errors.length; i++) {
-                    field.getForm().getElement().setAttribute(dataAttributesNames.errors[i], '1');
+                for (var i = 0; i < dataAttributesNames[listKey].length; i++) {
+                    field.getForm().getElement().setAttribute(dataAttributesNames[listKey][i], '1');
                 }
             },
 
             saveAllDataAttributes: function () {
                 dataAttributesNames.save = {
                     valid: field.isValid(),
-                    errors: dataAttributesNames.errors
+                    errors: dataAttributesNames.errors,
+                    warnings: dataAttributesNames.warnings,
+                    notices: dataAttributesNames.notices
                 };
             },
 
@@ -92,13 +109,17 @@ Formz.Field.DataAttributesService = (function () {
                 this.saveAllDataAttributes();
                 this.removeValueDataAttribute();
                 this.removeValidDataAttribute();
-                this.removeErrorsDataAttributes();
+                this.removeMessagesDataAttributes();
             },
 
             restoreAllDataAttributes: function () {
                 this.refreshValueDataAttribute();
                 dataAttributesNames.errors = dataAttributesNames.save.errors;
-                this.refreshErrorsDataAttributes();
+                dataAttributesNames.warnings = dataAttributesNames.save.warnings;
+                dataAttributesNames.notices = dataAttributesNames.save.notices;
+                this.refreshMessagesDataAttributes('error');
+                this.refreshMessagesDataAttributes('warning');
+                this.refreshMessagesDataAttributes('notice');
                 if (true === dataAttributesNames.save.valid) {
                     this.addValidDataAttribute();
                 }
@@ -115,8 +136,8 @@ Formz.Field.DataAttributesService = (function () {
             return servicePrototype({field: field});
         },
 
-        getFieldErrorDataName: function(field, validationName, errorName) {
-            return 'formz-error-' + Formz.camelCaseToDashed(field.getName())
+        getFieldMessageDataName: function(field, type, validationName, errorName) {
+            return 'formz-' + type + '-' + Formz.camelCaseToDashed(field.getName())
                 + '-' + Formz.camelCaseToDashed(validationName)
                 + '-' + Formz.camelCaseToDashed(errorName);
         }

--- a/Resources/Public/JavaScript/Field/Formz.Field.ValidationService.js
+++ b/Resources/Public/JavaScript/Field/Formz.Field.ValidationService.js
@@ -5,7 +5,9 @@ Formz.Field.ValidationService = (function () {
      * @param {Function}                           states.validationDataCallback
      * @param {Formz.Field.EventsManagerInstance}  states.eventsManager
      * @param {String}                             states.defaultErrorMessage
-     * @param {Array}                              states.existingErrors
+     * @param {Object}                             states.existingErrors
+     * @param {Object}                             states.existingWarnings
+     * @param {Object}                             states.existingNotices
      * @param {string}                             states.submittedFieldValue
      * @param {boolean}                            states.wasValidated
      * @returns {Formz.Field.ValidationServiceInstance}
@@ -81,6 +83,20 @@ Formz.Field.ValidationService = (function () {
          * @type {Object<Object>}
          */
         var errors = states.existingErrors || {};
+
+        /**
+         * Contains the current warnings found by this validation service.
+         *
+         * @type {Object<Object>}
+         */
+        var warnings = states.existingWarnings || {};
+
+        /**
+         * Contains the current notices found by this validation service.
+         *
+         * @type {Object<Object>}
+         */
+        var notices = states.existingNotices || {};
 
         /**
          * @type {boolean}
@@ -240,9 +256,30 @@ Formz.Field.ValidationService = (function () {
             validationRunning = false;
             if (result.hasErrors()) {
                 var errors = result.getErrors();
+
                 for (var errorName in errors) {
                     if (errors.hasOwnProperty(errorName)) {
                         addError(validationRuleName, errorName, errors[errorName]);
+                    }
+                }
+            }
+
+            if (result.hasWarnings()) {
+                var warnings = result.getWarnings();
+
+                for (var warningName in warnings) {
+                    if (warnings.hasOwnProperty(warningName)) {
+                        addWarning(validationRuleName, warningName, warnings[warningName]);
+                    }
+                }
+            }
+            
+            if (result.hasNotices()) {
+                var notices = result.getNotices();
+
+                for (var noticeName in notices) {
+                    if (notices.hasOwnProperty(noticeName)) {
+                        addNotice(validationRuleName, noticeName, notices[noticeName]);
                     }
                 }
             }
@@ -276,23 +313,53 @@ Formz.Field.ValidationService = (function () {
          * Adds an error to this field.
          *
          * @param {string} validatorName Name of the validator which returned the error.
-         * @param {string} errorName     Name of the error, e.g. "default".
+         * @param {string} name          Name of the error, e.g. "default".
          * @param {string} message       Message of the error.
          */
-        var addError = function (validatorName, errorName, message) {
+        var addError = function (validatorName, name, message) {
             if (false == validatorName in errors) {
                 errors[validatorName] = {};
             }
-            errors[validatorName][errorName] = message;
+            errors[validatorName][name] = message;
             lastValidationErrorName = validatorName;
+        };
+
+        /**
+         * Adds an warning to this field.
+         *
+         * @param {string} validatorName Name of the validator which returned the warning.
+         * @param {string} name          Name of the warning, e.g. "default".
+         * @param {string} message       Message of the warning.
+         */
+        var addWarning = function (validatorName, name, message) {
+            if (false == validatorName in warnings) {
+                warnings[validatorName] = {};
+            }
+            warnings[validatorName][name] = message;
+        };
+        
+        /**
+         * Adds an notice to this field.
+         *
+         * @param {string} validatorName Name of the validator which returned the notice.
+         * @param {string} name          Name of the notice, e.g. "default".
+         * @param {string} message       Message of the notice.
+         */
+        var addNotice = function (validatorName, name, message) {
+            if (false == validatorName in notices) {
+                notices[validatorName] = {};
+            }
+            notices[validatorName][name] = message;
         };
 
         /**
          * Resets the errors of this field.
          */
-        var resetErrors = function () {
+        var resetMessages = function () {
             lastValidationErrorName = null;
             errors = {};
+            warnings = {};
+            notices = {};
         };
 
         /**
@@ -371,7 +438,7 @@ Formz.Field.ValidationService = (function () {
 
                 validationRunning = true;
 
-                resetErrors();
+                resetMessages();
                 validatorsCheckedDuringLastValidation = [];
                 wasValidated = true;
                 lastValidatedValue = getStringValue();
@@ -651,6 +718,24 @@ Formz.Field.ValidationService = (function () {
             },
 
             /**
+             * @see getErrors()
+             *
+             * @returns {Object.<Object>}
+             */
+            getWarnings: function () {
+                return warnings;
+            },
+            
+            /**
+             * @see getErrors()
+             *
+             * @returns {Object.<Object>}
+             */
+            getNotices: function () {
+                return notices;
+            },
+
+            /**
              * Returns the last validator name which caused an error.
              *
              * @returns {?string}
@@ -716,7 +801,9 @@ Formz.Field.ValidationService = (function () {
         /**
          * @param {Object}                      states
          * @param {Formz.FullField}             states.field
-         * @param {Array}                       states.existingErrors
+         * @param {Object}                      states.existingErrors
+         * @param {Object}                      states.existingWarnings
+         * @param {Object}                      states.existingNotices
          * @param {string}                      states.submittedFieldValue
          * @param {boolean}                     states.wasValidated
          * @param {Formz.EventsManagerInstance} states.eventsManager
@@ -737,6 +824,8 @@ Formz.Field.ValidationService = (function () {
                 eventsManager: states.eventsManager,
                 defaultErrorMessage: states.field.getForm().getConfiguration()['settings']['defaultErrorMessage'],
                 existingErrors: states.existingErrors,
+                existingWarnings: states.existingWarnings,
+                existingNotices: states.existingNotices,
                 submittedFieldValue: states.submittedFieldValue,
                 wasValidated: states.wasValidated
             });

--- a/Resources/Public/JavaScript/Field/Formz.Field.ValidationService.js
+++ b/Resources/Public/JavaScript/Field/Formz.Field.ValidationService.js
@@ -10,6 +10,7 @@ Formz.Field.ValidationService = (function () {
      * @param {Object}                             states.existingNotices
      * @param {string}                             states.submittedFieldValue
      * @param {boolean}                            states.wasValidated
+     * @param {boolean}                            states.isDeactivated
      * @returns {Formz.Field.ValidationServiceInstance}
      */
     var servicePrototype = function (states) {
@@ -128,6 +129,11 @@ Formz.Field.ValidationService = (function () {
         var validatorsCheckedDuringLastValidation = (true === states.wasValidated)
             ? '*'
             : [];
+
+        /**
+         * @type {boolean}
+         */
+        var isDeactivated = states.isDeactivated;
 
         /**
          * Internal recursive function to validate the field.
@@ -273,7 +279,7 @@ Formz.Field.ValidationService = (function () {
                     }
                 }
             }
-            
+
             if (result.hasNotices()) {
                 var notices = result.getNotices();
 
@@ -337,7 +343,7 @@ Formz.Field.ValidationService = (function () {
             }
             warnings[validatorName][name] = message;
         };
-        
+
         /**
          * Adds an notice to this field.
          *
@@ -360,6 +366,20 @@ Formz.Field.ValidationService = (function () {
             errors = {};
             warnings = {};
             notices = {};
+        };
+
+        var activate = function () {
+            if (true === isDeactivated) {
+                isDeactivated = false;
+                eventsManager.dispatch('reactivated');
+            }
+        };
+
+        var deactivate = function () {
+            if (false === isDeactivated) {
+                isDeactivated = true;
+                eventsManager.dispatch('deactivated');
+            }
         };
 
         /**
@@ -675,14 +695,14 @@ Formz.Field.ValidationService = (function () {
                     var self = this;
 
                     var stopValidationCallBack = function () {
-                        eventsManager.dispatch('deactivated');
+                        deactivate();
                     };
 
                     var endingCallBack = function () {
                         if (getStringValue() !== lastValidatedValue) {
                             self.validate();
                         } else {
-                            eventsManager.dispatch('reactivated');
+                            activate();
                         }
                     };
 
@@ -725,7 +745,7 @@ Formz.Field.ValidationService = (function () {
             getWarnings: function () {
                 return warnings;
             },
-            
+
             /**
              * @see getErrors()
              *
@@ -806,6 +826,7 @@ Formz.Field.ValidationService = (function () {
          * @param {Object}                      states.existingNotices
          * @param {string}                      states.submittedFieldValue
          * @param {boolean}                     states.wasValidated
+         * @param {boolean}                     states.isDeactivated
          * @param {Formz.EventsManagerInstance} states.eventsManager
          * @returns {Formz.Field.ValidationServiceInstance}
          */
@@ -827,7 +848,8 @@ Formz.Field.ValidationService = (function () {
                 existingWarnings: states.existingWarnings,
                 existingNotices: states.existingNotices,
                 submittedFieldValue: states.submittedFieldValue,
-                wasValidated: states.wasValidated
+                wasValidated: states.wasValidated,
+                isDeactivated: states.isDeactivated
             });
         }
     }

--- a/Resources/Public/JavaScript/Field/Formz.Field.js
+++ b/Resources/Public/JavaScript/Field/Formz.Field.js
@@ -66,13 +66,13 @@ Formz.Field = (function () {
         return {
             /**
              * Will empty the feedback container, which can be filled again with
-             * the function `insertErrors()`.
+             * the function `insertMessages()`.
              */
             refreshFeedback: function () {
-                var errorContainerElement = this.getFeedbackListContainer();
+                var feedbackListContainerElement = this.getFeedbackListContainer();
 
-                if (errorContainerElement != null) {
-                    errorContainerElement.innerHTML = '';
+                if (feedbackListContainerElement != null) {
+                    feedbackListContainerElement.innerHTML = '';
                 }
 
                 eventsManager.dispatch('refreshFeedback');
@@ -82,26 +82,27 @@ Formz.Field = (function () {
              * Will refresh the messages displayed in the feedback container of
              * this field.
              *
-             * @param {Object} errors
+             * @param {Object} messages
+             * @param {string} type
              */
-            insertErrors: function (errors) {
-                var errorContainerElement = this.getFeedbackListContainer();
+            insertMessages: function (messages, type) {
+                var feedbackListContainerElement = this.getFeedbackListContainer();
 
-                if (errorContainerElement != null) {
-                    if (Formz.objectSize(errors) > 0) {
+                if (feedbackListContainerElement != null) {
+                    if (Formz.objectSize(messages) > 0) {
                         var messageTemplate = this.getMessageTemplate();
 
-                        for (var validationRuleName in errors) {
-                            if (errors.hasOwnProperty(validationRuleName)) {
-                                for (var errorName in errors[validationRuleName]) {
-                                    if (errors[validationRuleName].hasOwnProperty(errorName)) {
-                                        errorContainerElement.innerHTML += messageTemplate
+                        for (var validationRuleName in messages) {
+                            if (messages.hasOwnProperty(validationRuleName)) {
+                                for (var name in messages[validationRuleName]) {
+                                    if (messages[validationRuleName].hasOwnProperty(name)) {
+                                        feedbackListContainerElement.innerHTML += messageTemplate
                                             .replace('#FIELD#', this.getName())
                                             .replace('#FIELD_ID#', Formz.camelCaseToDashed('formz-' + this.getForm().getName() + '-' + this.getName()))
                                             .replace('#VALIDATOR#', Formz.camelCaseToDashed(validationRuleName))
-                                            .replace('#TYPE#', 'error')
-                                            .replace('#KEY#', errorName)
-                                            .replace('#MESSAGE#', errors[validationRuleName][errorName]);
+                                            .replace('#TYPE#', type)
+                                            .replace('#KEY#', name)
+                                            .replace('#MESSAGE#', messages[validationRuleName][name]);
                                     }
                                 }
                             }
@@ -385,7 +386,9 @@ Formz.Field = (function () {
 
                 // Emptying the field feedback container.
                 states.field.refreshFeedback();
-                states.field.insertErrors(states.field.getErrors());
+                states.field.insertMessages(states.field.getErrors(), 'error');
+                states.field.insertMessages(states.field.getWarnings(), 'warning');
+                states.field.insertMessages(states.field.getNotices(), 'notice');
             });
 
             states.field.onValidationDone(function () {
@@ -508,12 +511,14 @@ Formz.Field = (function () {
          * @param {string}             name
          * @param {Object}             configuration
          * @param {Formz.FormInstance} form
-         * @param {Array}              existingErrors
+         * @param {Object}             existingErrors
+         * @param {Object}             existingWarnings
+         * @param {Object}             existingNotices
          * @param {string}             submittedFieldValue
          * @param {boolean}            wasValidated
          * @returns {?Formz.FullField}
          */
-        get: function (name, configuration, form, existingErrors, submittedFieldValue, wasValidated) {
+        get: function (name, configuration, form, existingErrors, existingWarnings, existingNotices, submittedFieldValue, wasValidated) {
             if ('' === name || null === form) {
                 return null;
             }
@@ -522,6 +527,8 @@ Formz.Field = (function () {
                 name: name,
                 configuration: configuration,
                 existingErrors: existingErrors,
+                existingWarnings: existingWarnings,
+                existingNotices: existingNotices,
                 submittedFieldValue: submittedFieldValue,
                 wasValidated: wasValidated,
                 form: form,

--- a/Resources/Public/JavaScript/Form/Formz.Form.js
+++ b/Resources/Public/JavaScript/Form/Formz.Form.js
@@ -47,7 +47,7 @@ Formz.Form = (function () {
         /**
          * @type {Object<Array>}
          */
-        var existingErrors = {};
+        var existingMessages = {};
 
         /**
          * @type {boolean}
@@ -82,9 +82,23 @@ Formz.Form = (function () {
             var configurationFields = configuration['fields'];
             for (var fieldName in configurationFields) {
                 if (configurationFields.hasOwnProperty(fieldName)) {
-                    var fieldExistingErrors = (fieldName in existingErrors)
-                        ? existingErrors[fieldName]
-                        : [];
+                    var existingErrors = {};
+                    var existingWarning = {};
+                    var existingNotices = {};
+
+                    if (fieldName in existingMessages) {
+                        var fieldExistingMessages = existingMessages[fieldName];
+
+                        if ('errors' in fieldExistingMessages) {
+                            existingErrors = fieldExistingMessages['errors'];
+                        }
+                        if ('warnings' in fieldExistingMessages) {
+                            existingWarning = fieldExistingMessages['warnings'];
+                        }
+                        if ('notices' in fieldExistingMessages) {
+                            existingNotices = fieldExistingMessages['notices'];
+                        }
+                    }
 
                     var submittedFieldValue = (fieldName in submittedValues)
                         ? submittedValues[fieldName]
@@ -94,7 +108,9 @@ Formz.Form = (function () {
                         fieldName,
                         configurationFields[fieldName],
                         formInstance,
-                        fieldExistingErrors,
+                        existingErrors,
+                        existingWarning,
+                        existingNotices,
                         submittedFieldValue,
                         formWasValidated
                     );
@@ -195,12 +211,12 @@ Formz.Form = (function () {
 
             /**
              * @param {string}  submittedFormValues
-             * @param {string}  existingFormErrors
+             * @param {string}  existingFormMessages
              * @param {boolean} formValidationDone
              */
-            injectRequestData: function (submittedFormValues, existingFormErrors, formValidationDone) {
+            injectRequestData: function (submittedFormValues, existingFormMessages, formValidationDone) {
                 submittedValues = submittedFormValues;
-                existingErrors = existingFormErrors;
+                existingMessages = existingFormMessages;
                 formWasValidated = formValidationDone;
             }
         };

--- a/Resources/Public/JavaScript/Form/Formz.Form.js
+++ b/Resources/Public/JavaScript/Form/Formz.Form.js
@@ -67,6 +67,11 @@ Formz.Form = (function () {
         var fieldsHaveBeenInitialized = false;
 
         /**
+         * @type {Array}
+         */
+        var deactivatedFields = [];
+
+        /**
          * Initializes all the fields of this form: an instance is created for
          * every field.
          *
@@ -104,6 +109,8 @@ Formz.Form = (function () {
                         ? submittedValues[fieldName]
                         : '';
 
+                    var isDeactivated = -1 !== deactivatedFields.indexOf(fieldName);
+
                     var field = Formz.Field.get(
                         fieldName,
                         configurationFields[fieldName],
@@ -112,7 +119,8 @@ Formz.Form = (function () {
                         existingWarning,
                         existingNotices,
                         submittedFieldValue,
-                        formWasValidated
+                        formWasValidated,
+                        isDeactivated
                     );
                     if (field.getElements().length > 0) {
                         fields[fieldName] = field;
@@ -213,11 +221,13 @@ Formz.Form = (function () {
              * @param {string}  submittedFormValues
              * @param {string}  existingFormMessages
              * @param {boolean} formValidationDone
+             * @param {Array}   deactivatedFieldsNames
              */
-            injectRequestData: function (submittedFormValues, existingFormMessages, formValidationDone) {
+            injectRequestData: function (submittedFormValues, existingFormMessages, formValidationDone, deactivatedFieldsNames) {
                 submittedValues = submittedFormValues;
                 existingMessages = existingFormMessages;
                 formWasValidated = formValidationDone;
+                deactivatedFields = deactivatedFieldsNames;
             }
         };
 

--- a/Resources/Public/JavaScript/Formz.Result.js
+++ b/Resources/Public/JavaScript/Formz.Result.js
@@ -18,12 +18,62 @@ Formz.Result = (function () {
          *
          * @type {Object<string>}
          */
-        var errorsMessages = {};
+        var errorMessages = {};
+
+        /**
+         * Contains all the warning messages.
+         *
+         * @type {Object<string>}
+         */
+        var warningMessages = {};
+
+        /**
+         * Contains all the notice messages.
+         *
+         * @type {Object<string>}
+         */
+        var noticeMessages = {};
 
         /**
          * @type {Object}
          */
         var data = {};
+
+        /**
+         * @param {Object} states             Object containing informations.
+         * @param {string} states.name        Name (key) of the message.
+         * @param {string} states.message     Text of the message.
+         * @param {Array}  [states.arguments] Arguments to be replaced in the translated message.
+         */
+        var sanitizeMessageStates = function (states) {
+            var name = states.name || 'default';
+            var message = states.message || '';
+            var arguments = states.arguments || [];
+
+            if (null === message
+                || typeof message === 'undefined'
+            ) {
+                message = '';
+            }
+
+            message = message.toString();
+
+            if ('' === message) {
+                message = defaultErrorMessage;
+            }
+
+            message = Formz.Localization.getLocalization(message);
+
+            for (var i = 0; i < arguments.length; i++) {
+                message = message.replace('{' + i + '}', arguments[i].toString());
+            }
+
+            return {
+                name: name,
+                message: message,
+                arguments: arguments
+            };
+        };
 
         /**
          * @namespace Formz.ResultInstance
@@ -39,38 +89,17 @@ Formz.Result = (function () {
              * @param {Array}  [states.arguments] Arguments to be replaced in the translated message.
              */
             addError: function (states) {
-                var name = states.name || 'default';
-                var message = states.message || '';
-                var arguments = states.arguments || [];
-
-                if (null === message
-                    || typeof message === 'undefined'
-                ) {
-                    message = '';
-                }
-
-                message = message.toString();
-
-                if ('' === message) {
-                    message = defaultErrorMessage;
-                }
-
-                message = Formz.Localization.getLocalization(message);
-
-                for (var i = 0; i < arguments.length; i++) {
-                    message = message.replace('{' + i + '}', arguments[i].toString());
-                }
-
-                errorsMessages[name] = message;
+                states = sanitizeMessageStates(states);
+                errorMessages[states.name] = states.message;
             },
 
             /**
-             * Returns the errors messages of the result.
+             * Returns the error messages of the result.
              *
              * @returns {Object<string>}
              */
             getErrors: function () {
-                return errorsMessages;
+                return errorMessages;
             },
 
             /**
@@ -79,7 +108,69 @@ Formz.Result = (function () {
              * @returns {boolean}
              */
             hasErrors: function () {
-                return Formz.objectSize(errorsMessages) > 0;
+                return Formz.objectSize(errorMessages) > 0;
+            },
+
+            /**
+             * Adds a warning to the result.
+             *
+             * @param {Object} states             Object containing informations.
+             * @param {string} states.name        Name (key) of the message.
+             * @param {string} states.message     Text of the message.
+             * @param {Array}  [states.arguments] Arguments to be replaced in the translated message.
+             */
+            addWarning: function (states) {
+                states = sanitizeMessageStates(states);
+                warningMessages[states.name] = states.message;
+            },
+
+            /**
+             * Returns the warning messages of the result.
+             *
+             * @returns {Object<string>}
+             */
+            getWarnings: function () {
+                return warningMessages;
+            },
+
+            /**
+             * Returns true if the result contains warnings.
+             *
+             * @returns {boolean}
+             */
+            hasWarnings: function () {
+                return Formz.objectSize(warningMessages) > 0;
+            },
+            
+            /**
+             * Adds a notice to the result.
+             *
+             * @param {Object} states             Object containing informations.
+             * @param {string} states.name        Name (key) of the message.
+             * @param {string} states.message     Text of the message.
+             * @param {Array}  [states.arguments] Arguments to be replaced in the translated message.
+             */
+            addNotice: function (states) {
+                states = sanitizeMessageStates(states);
+                noticeMessages[states.name] = states.message;
+            },
+
+            /**
+             * Returns the notice messages of the result.
+             *
+             * @returns {Object<string>}
+             */
+            getNotices: function () {
+                return noticeMessages;
+            },
+
+            /**
+             * Returns true if the result contains notices.
+             *
+             * @returns {boolean}
+             */
+            hasNotices: function () {
+                return Formz.objectSize(noticeMessages) > 0;
             },
 
             /**

--- a/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
+++ b/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
@@ -2,6 +2,32 @@
     // @todo
     var checkValues = {};
 
+    /**
+     * @param {Object}               messages
+     * @param {string}               type
+     * @param {Formz.ResultInstance} result
+     */
+    var addMessages = function(messages, type, result) {
+        if (type in messages) {
+            for (var key in messages[type]) {
+                if (messages[type].hasOwnProperty(key)) {
+                    var message = {
+                        name: key,
+                        message: messages[type][key]
+                    };
+
+                    if (type === 'errors') {
+                        result.addError(message);
+                    } else if (type === 'warnings') {
+                        result.addWarning(message);
+                    } else if (type === 'notices') {
+                        result.addNotice(message);
+                    }
+                }
+            }
+        }
+    };
+
     Formz.Validation.registerValidator(
         'AjaxValidator',
         /**
@@ -20,6 +46,7 @@
             if (value !== '') {
                 var addDefaultError = function() {
                     var message = field.getForm().getConfiguration()['settings']['defaultErrorMessage'];
+
                     states['result'].addError({
                         name: 'default',
                         message: message
@@ -42,11 +69,12 @@
                             var ajaxResult = JSON.parse(request.responseText);
 
                             if (false === ajaxResult['success']) {
-                                if ('message' in ajaxResult) {
-                                    states['result'].addError({
-                                        name: 'default',
-                                        message: ajaxResult['message']
-                                    });
+                                if ('messages' in ajaxResult) {
+                                    var messages = ajaxResult['messages'];
+
+                                    addMessages(messages, 'errors', states['result']);
+                                    addMessages(messages, 'warnings', states['result']);
+                                    addMessages(messages, 'notices', states['result']);
                                 } else {
                                     addDefaultError();
                                 }

--- a/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
+++ b/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
@@ -68,16 +68,18 @@
                         try {
                             var ajaxResult = JSON.parse(request.responseText);
 
-                            if (false === ajaxResult['success']) {
-                                if ('messages' in ajaxResult) {
-                                    var messages = ajaxResult['messages'];
+                            if ('messages' in ajaxResult) {
+                                var messages = ajaxResult['messages'];
 
-                                    addMessages(messages, 'errors', states['result']);
-                                    addMessages(messages, 'warnings', states['result']);
-                                    addMessages(messages, 'notices', states['result']);
-                                } else {
-                                    addDefaultError();
-                                }
+                                addMessages(messages, 'errors', states['result']);
+                                addMessages(messages, 'warnings', states['result']);
+                                addMessages(messages, 'notices', states['result']);
+                            }
+
+                            if (false === ajaxResult['success']
+                                && false === states['result'].hasErrors()
+                            ) {
+                                addDefaultError();
                             }
 
                             callback();

--- a/Tests/Fixture/Validation/Validator/MessagesValidator.php
+++ b/Tests/Fixture/Validation/Validator/MessagesValidator.php
@@ -1,0 +1,36 @@
+<?php
+namespace Romm\Formz\Tests\Fixture\Validation\Validator;
+
+use Romm\Formz\Validation\Validator\AbstractValidator;
+
+class MessagesValidator extends AbstractValidator
+{
+    const MESSAGE_1 = 'message1';
+    const MESSAGE_2 = 'message2';
+    const MESSAGE_3 = 'message3';
+
+    /**
+     * @var array
+     */
+    protected $supportedMessages = [
+        self::MESSAGE_1 => [
+            'value' => self::MESSAGE_1
+        ],
+        self::MESSAGE_2 => [
+            'value' => self::MESSAGE_2
+        ],
+        self::MESSAGE_3 => [
+            'value' => self::MESSAGE_3
+        ]
+    ];
+
+    /**
+     * @param mixed $value
+     */
+    public function isValid($value)
+    {
+        $this->addError(self::MESSAGE_1, 42);
+        $this->addWarning(self::MESSAGE_2, 42);
+        $this->addNotice(self::MESSAGE_3, 42);
+    }
+}

--- a/Tests/Unit/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandlerTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace Romm\Formz\Tests\Unit\AssetHandler\Css;
 
-use Romm\Formz\AssetHandler\Css\ErrorContainerDisplayCssAssetHandler;
+use Romm\Formz\AssetHandler\Css\FeedbackContainerDisplayCssAssetHandler;
 use Romm\Formz\Tests\Fixture\Form\DefaultForm;
 use Romm\Formz\Tests\Unit\AbstractUnitTest;
 use Romm\Formz\Tests\Unit\AssetHandler\AssetHandlerTestTrait;
 
-class ErrorContainerDisplayCssAssetHandlerTest extends AbstractUnitTest
+class FeedbackContainerDisplayCssAssetHandlerTest extends AbstractUnitTest
 {
     use AssetHandlerTestTrait;
 
@@ -21,8 +21,8 @@ class ErrorContainerDisplayCssAssetHandlerTest extends AbstractUnitTest
 
         $assetHandlerFactory = $this->getAssetHandlerFactoryInstance(DefaultForm::class);
 
-        /** @var ErrorContainerDisplayCssAssetHandler $errorContainerDisplayCssAssetHandler */
-        $errorContainerDisplayCssAssetHandler = $assetHandlerFactory->getAssetHandler(ErrorContainerDisplayCssAssetHandler::class);
+        /** @var FeedbackContainerDisplayCssAssetHandler $errorContainerDisplayCssAssetHandler */
+        $errorContainerDisplayCssAssetHandler = $assetHandlerFactory->getAssetHandler(FeedbackContainerDisplayCssAssetHandler::class);
         $errorContainerDisplayCss = $errorContainerDisplayCssAssetHandler->getErrorContainerDisplayCss();
 
         $this->assertEquals($this->trimString($errorContainerDisplayCss), $expectedCss);

--- a/Tests/Unit/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Css/FeedbackContainerDisplayCssAssetHandlerTest.php
@@ -17,7 +17,7 @@ class FeedbackContainerDisplayCssAssetHandlerTest extends AbstractUnitTest
      */
     public function errorContainerDisplayCssIsValid()
     {
-        $expectedCss = 'form[name="foo"]:not([formz-error-foo="1"])[formz-field-feedback-container="foo"]{display:none!important;}';
+        $expectedCss = 'form[name="foo"]:not([formz-error-foo="1"]):not([formz-warning-foo="1"]):not([formz-notice-foo="1"])[formz-field-feedback-container="foo"]{display:none!important;}';
 
         $assetHandlerFactory = $this->getAssetHandlerFactoryInstance(DefaultForm::class);
 
@@ -25,7 +25,7 @@ class FeedbackContainerDisplayCssAssetHandlerTest extends AbstractUnitTest
         $errorContainerDisplayCssAssetHandler = $assetHandlerFactory->getAssetHandler(FeedbackContainerDisplayCssAssetHandler::class);
         $errorContainerDisplayCss = $errorContainerDisplayCssAssetHandler->getErrorContainerDisplayCss();
 
-        $this->assertEquals($this->trimString($errorContainerDisplayCss), $expectedCss);
+        $this->assertEquals($expectedCss, $this->trimString($errorContainerDisplayCss));
 
         unset($assetHandlerFactory);
     }

--- a/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
@@ -71,7 +71,7 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
 
         /** @var DataAttributesAssetHandler $dataAttributesAssetHandler */
         $dataAttributesAssetHandler = $assetHandlerFactory->getAssetHandler(DataAttributesAssetHandler::class);
-        $dataAttributesValues = $dataAttributesAssetHandler->getFieldsErrorsDataAttributes($requestResult);
+        $dataAttributesValues = $dataAttributesAssetHandler->getFieldsMessagesDataAttributes($requestResult);
 
         $this->assertEquals($expectedResult, $dataAttributesValues);
 
@@ -89,8 +89,8 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
         return [
             'defaultSingleErrorCheck'  => [
                 [
-                    DataAttributesAssetHandler::getFieldDataErrorKey('foo')                                 => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('foo', 'unknown', 'unknown') => '1'
+                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                          => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'unknown', 'unknown') => '1'
                 ],
                 [
                     'foo' => [
@@ -102,8 +102,8 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
             ],
             'customSingleErrorCheck'   => [
                 [
-                    DataAttributesAssetHandler::getFieldDataErrorKey('foo')                             => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('foo', 'hello', 'world') => '1'
+                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                      => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'hello', 'world') => '1'
                 ],
                 [
                     'foo' => [
@@ -117,9 +117,9 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
             ],
             'multipleErrorCheck'       => [
                 [
-                    DataAttributesAssetHandler::getFieldDataErrorKey('foo')                                 => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('foo', 'unknown', 'unknown') => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('foo', 'hello', 'world')     => '1'
+                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                          => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'unknown', 'unknown') => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'hello', 'world')     => '1'
                 ],
                 [
                     'foo' => [
@@ -136,11 +136,11 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
             ],
             'multipleFieldsErrorCheck' => [
                 [
-                    DataAttributesAssetHandler::getFieldDataErrorKey('foo')                                 => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('foo', 'unknown', 'unknown') => '1',
-                    DataAttributesAssetHandler::getFieldDataErrorKey('bar')                                 => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('bar', 'unknown', 'unknown') => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationErrorKey('bar', 'hello', 'world')     => '1'
+                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                          => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'unknown', 'unknown') => '1',
+                    DataAttributesAssetHandler::getFieldDataMessageKey('bar')                                          => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'unknown', 'unknown') => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'hello', 'world')     => '1'
                 ],
                 [
                     'foo' => [

--- a/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Html/DataAttributesAssetHandlerTest.php
@@ -2,7 +2,6 @@
 namespace Romm\Formz\Tests\Unit\AssetHandler\Css;
 
 use Romm\Formz\AssetHandler\Html\DataAttributesAssetHandler;
-use Romm\Formz\Error\Error;
 use Romm\Formz\Error\FormResult;
 use Romm\Formz\Tests\Fixture\Form\ExtendedForm;
 use Romm\Formz\Tests\Unit\AbstractUnitTest;
@@ -45,27 +44,30 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
      * Checks that the field error data attributes are valid.
      *
      * @param array $expectedResult
-     * @param array $fieldErrors
+     * @param array $fieldMessages
      *
      * @dataProvider checkFieldsErrorsDataAttributesDataProvider
      * @test
      */
-    public function checkFieldsErrorsDataAttributes(array $expectedResult, array $fieldErrors)
+    public function checkFieldsErrorsDataAttributes(array $expectedResult, array $fieldMessages)
     {
         $assetHandlerFactory = $this->getAssetHandlerFactoryInstance(ExtendedForm::class);
         $requestResult = new FormResult();
 
-        foreach ($fieldErrors as $fieldName => $errors) {
-            foreach ($errors as $errorData) {
-                $error = new Error(
-                    $errorData['message'],
+        foreach ($fieldMessages as $fieldName => $messages) {
+            foreach ($messages as $data) {
+                $type = 'Romm\\Formz\\Error\\' . ucfirst($data['type']);
+                $addMethod = 'add' . ucfirst($data['type']);
+
+                $message = new $type(
+                    $data['message'],
                     42,
-                    $errorData['validationName'],
-                    $errorData['messageKey'],
+                    $data['validationName'],
+                    $data['messageKey'],
                     [],
                     ''
                 );
-                $requestResult->forProperty($fieldName)->addError($error);
+                $requestResult->forProperty($fieldName)->$addMethod($message);
             }
         }
 
@@ -95,6 +97,7 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
                 [
                     'foo' => [
                         [
+                            'type'    => 'error',
                             'message' => 'foo'
                         ]
                     ]
@@ -108,6 +111,7 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
                 [
                     'foo' => [
                         [
+                            'type'           => 'error',
                             'message'        => 'foo',
                             'validationName' => 'hello',
                             'messageKey'     => 'world'
@@ -124,9 +128,11 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
                 [
                     'foo' => [
                         [
+                            'type'    => 'error',
                             'message' => 'foo'
                         ],
                         [
+                            'type'           => 'error',
                             'message'        => 'foo',
                             'validationName' => 'hello',
                             'messageKey'     => 'world'
@@ -136,26 +142,41 @@ class DataAttributesAssetHandlerTest extends AbstractUnitTest
             ],
             'multipleFieldsErrorCheck' => [
                 [
-                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                          => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'unknown', 'unknown') => '1',
-                    DataAttributesAssetHandler::getFieldDataMessageKey('bar')                                          => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'unknown', 'unknown') => '1',
-                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'hello', 'world')     => '1'
+                    DataAttributesAssetHandler::getFieldDataMessageKey('foo')                                            => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('foo', 'error', 'unknown', 'unknown')   => '1',
+                    DataAttributesAssetHandler::getFieldDataMessageKey('bar')                                            => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'unknown', 'unknown')   => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'error', 'hello', 'world')       => '1',
+                    DataAttributesAssetHandler::getFieldDataMessageKey('bar', 'warning')                                 => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'warning', 'unknown', 'unknown') => '1',
+                    DataAttributesAssetHandler::getFieldDataMessageKey('bar', 'notice')                                  => '1',
+                    DataAttributesAssetHandler::getFieldDataValidationMessageKey('bar', 'notice', 'unknown', 'unknown')  => '1'
                 ],
                 [
                     'foo' => [
                         [
+                            'type'    => 'error',
                             'message' => 'foo'
                         ]
                     ],
                     'bar' => [
                         [
+                            'type'    => 'error',
                             'message' => 'bar'
                         ],
                         [
+                            'type'           => 'error',
                             'message'        => 'bar',
                             'validationName' => 'hello',
                             'messageKey'     => 'world'
+                        ],
+                        [
+                            'type'    => 'warning',
+                            'message' => 'bar'
+                        ],
+                        [
+                            'type'    => 'notice',
+                            'message' => 'bar'
                         ]
                     ]
                 ]

--- a/Tests/Unit/AssetHandler/JavaScript/FormRequestDataJavaScriptAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/JavaScript/FormRequestDataJavaScriptAssetHandlerTest.php
@@ -21,7 +21,7 @@ class FormRequestDataJavaScriptAssetHandlerTest extends AbstractUnitTest
     public function checkJavaScriptCode()
     {
         $expectedResult = <<<TXT
-(function(){Formz.Form.beforeInitialization('foo',function(form){form.injectRequestData({"foo":"foo"},{"foo":{"foo":{"bar":"error"}}},true)});})();
+(function(){Formz.Form.beforeInitialization('foo',function(form){form.injectRequestData({"foo":"foo"},{"foo":{"errors":{"foo":{"bar":"error"}}}},true)});})();
 TXT;
 
         $originalRequest = new Request();

--- a/Tests/Unit/Controller/AjaxValidationControllerTest.php
+++ b/Tests/Unit/Controller/AjaxValidationControllerTest.php
@@ -14,6 +14,7 @@ use Romm\Formz\Service\ContextService;
 use Romm\Formz\Tests\Fixture\Form\DefaultForm;
 use Romm\Formz\Tests\Fixture\Validation\Validator\DummyValidator;
 use Romm\Formz\Tests\Fixture\Validation\Validator\ExceptionDummyValidator;
+use Romm\Formz\Tests\Fixture\Validation\Validator\MessagesValidator;
 use Romm\Formz\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Mvc\View\JsonView;
@@ -152,7 +153,7 @@ class AjaxValidationControllerTest extends AbstractUnitTest
      *
      * @test
      */
-    public function ExceptionCatchInProtectedRequestWithDebugModeShouldCustomizeResultMessage()
+    public function exceptionCatchInProtectedRequestWithDebugModeShouldCustomizeResultMessage()
     {
         $formObject = $this->getDefaultFormObject();
         $validation = new Validation;
@@ -260,6 +261,39 @@ class AjaxValidationControllerTest extends AbstractUnitTest
         $validation->setValidationName('bar');
         $validation->activateAjaxUsage();
         $formObject->getConfiguration()->getField('foo')->addValidation($validation);
+
+        $ajaxValidationController = $this->getAjaxValidationControllerMockWithArgumentsHandling([], $formObject);
+
+        $ajaxValidationController->setProtectedRequestMode(false);
+        $ajaxValidationController->runAction();
+        $result = $ajaxValidationController->getView()->render();
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * Checks that errors, warnings and notices are added to the result array.
+     *
+     * @test
+     */
+    public function messagesTypesAreReturnedInResult()
+    {
+        $expectedResult = [
+            'success' => false,
+            'messages' => [
+                'errors' => [MessagesValidator::MESSAGE_1 => MessagesValidator::MESSAGE_1],
+                'warnings' => [MessagesValidator::MESSAGE_2 => MessagesValidator::MESSAGE_2],
+                'notices' => [MessagesValidator::MESSAGE_3 => MessagesValidator::MESSAGE_3]
+            ]
+        ];
+
+        $formObject = $this->getDefaultFormObject();
+
+        $messagesValidator = new Validation;
+        $messagesValidator->setClassName(MessagesValidator::class);
+        $messagesValidator->setValidationName('bar');
+        $messagesValidator->activateAjaxUsage();
+        $formObject->getConfiguration()->getField('foo')->addValidation($messagesValidator);
 
         $ajaxValidationController = $this->getAjaxValidationControllerMockWithArgumentsHandling([], $formObject);
 

--- a/Tests/Unit/Controller/AjaxValidationControllerTest.php
+++ b/Tests/Unit/Controller/AjaxValidationControllerTest.php
@@ -141,7 +141,7 @@ class AjaxValidationControllerTest extends AbstractUnitTest
         $this->assertFalse($result['success']);
         $this->assertEquals(
             ContextService::get()->translate(AjaxValidationController::DEFAULT_ERROR_MESSAGE_KEY),
-            $result['message'][0]
+            $result['messages']['errors']['default']
         );
     }
 
@@ -251,7 +251,7 @@ class AjaxValidationControllerTest extends AbstractUnitTest
     {
         $expectedResult = [
             'success' => true,
-            'message' => ''
+            'messages' => []
         ];
 
         $formObject = $this->getDefaultFormObject();
@@ -302,7 +302,6 @@ class AjaxValidationControllerTest extends AbstractUnitTest
 
                 return $method->invoke($view);
             });
-
 
         $this->inject($ajaxValidationController, 'view', $view);
 

--- a/Tests/Unit/Form/FormObjectTest.php
+++ b/Tests/Unit/Form/FormObjectTest.php
@@ -3,6 +3,7 @@ namespace Romm\Formz\Tests\Unit\Form;
 
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use Romm\Formz\Configuration\Configuration;
+use Romm\Formz\Error\FormResult;
 use Romm\Formz\Form\FormObject;
 use Romm\Formz\Tests\Unit\AbstractUnitTest;
 use TYPO3\CMS\Extbase\Error\Result;
@@ -232,5 +233,20 @@ class FormObjectTest extends AbstractUnitTest
         $this->assertFalse($validationResult->hasErrors());
 
         unset($formObject);
+    }
+
+    /**
+     * @test
+     */
+    public function setLastValidationResultSetsLastValidationResult()
+    {
+        $formObject = new FormObject('foo', 'foo');
+
+        $validationResult = new FormResult;
+
+        $this->assertFalse($formObject->hasLastValidationResult());
+        $formObject->setLastValidationResult($validationResult);
+        $this->assertTrue($formObject->hasLastValidationResult());
+        $this->assertSame($validationResult, $formObject->getLastValidationResult());
     }
 }

--- a/Tests/Unit/Validation/Validator/Form/AbstractFormValidatorTest.php
+++ b/Tests/Unit/Validation/Validator/Form/AbstractFormValidatorTest.php
@@ -79,7 +79,7 @@ class AbstractFormValidatorTest extends AbstractUnitTest
 
         /** @var FormValidatorExecutor|\PHPUnit_Framework_MockObject_MockObject $formValidatorExecutorMock */
         $formValidatorExecutorMock = $this->getMockBuilder(FormValidatorExecutor::class)
-            ->setMethods(['applyBehaviours', 'checkFieldsActivation', 'validateFields'])
+            ->setMethods(['applyBehaviours', 'checkFieldsActivation', 'validateFields', 'saveValidationResult'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -107,6 +107,13 @@ class AbstractFormValidatorTest extends AbstractUnitTest
             ->method('validateFields')
             ->willReturnCallback(function () use (&$counter) {
                 $this->assertEquals(2, $counter);
+                $counter++;
+            });
+
+        $formValidatorExecutorMock->expects($this->once())
+            ->method('saveValidationResult')
+            ->willReturnCallback(function () use (&$counter) {
+                $this->assertEquals(3, $counter);
             });
 
         $validatorMock->validate(new DefaultForm);

--- a/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
@@ -97,7 +97,7 @@ class FormatMessageViewHelperTest extends AbstractViewHelperUnitTest
             ],
             [
                 'message'  => new Message('foo', 1337),
-                'expected' => '<span class="js-validation-rule-unknown js-validation-type-message js-validation-message-unknown">foo</span>'
+                'expected' => '<span class="js-validation-rule-unknown-0 js-validation-type-message js-validation-message-unknown-1">foo</span>'
             ],
             [
                 'message'         => new Error('foo', 1337, 'bar', 'baz'),

--- a/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
@@ -97,7 +97,7 @@ class FormatMessageViewHelperTest extends AbstractViewHelperUnitTest
             ],
             [
                 'message'  => new Message('foo', 1337),
-                'expected' => '<span class="js-validation-rule-unknown-0 js-validation-type-message js-validation-message-unknown-1">foo</span>'
+                'expected' => '<span class="js-validation-rule-unknown-0 js-validation-type-message js-validation-message-unknown-0">foo</span>'
             ],
             [
                 'message'         => new Error('foo', 1337, 'bar', 'baz'),

--- a/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/FormatMessageViewHelperTest.php
@@ -96,10 +96,6 @@ class FormatMessageViewHelperTest extends AbstractViewHelperUnitTest
                 'expected' => '<span class="js-validation-rule-bar js-validation-type-notice js-validation-message-baz">foo</span>'
             ],
             [
-                'message'  => new Message('foo', 1337),
-                'expected' => '<span class="js-validation-rule-unknown-0 js-validation-type-message js-validation-message-unknown-0">foo</span>'
-            ],
-            [
                 'message'         => new Error('foo', 1337, 'bar', 'baz'),
                 'expected'        => 'foo - formz-foo-foo - error - bar - baz - foo',
                 'messageTemplate' => '#FIELD# - #FIELD_ID# - #TYPE# - #VALIDATOR# - #KEY# - #MESSAGE#'


### PR DESCRIPTION
This pull requests adds a more reliable handling of the `warning` and `notice` message types in validation rules.

These message wont block a validation (an error will), but can be used to deliver more information to the final user about actions done during the validation.

Ajax requests are supported.