### PR TITLE
[!!!][TASK] Change fields TypoScript configuration `activation` keys

### DIFF
--- a/Classes/Condition/Parser/ConditionParser.php
+++ b/Classes/Condition/Parser/ConditionParser.php
@@ -83,7 +83,10 @@ class ConditionParser implements SingletonInterface
 
         $rootNode = $rootNode ?: NullNode::get();
 
-        return GeneralUtility::makeInstance(ConditionTree::class, $rootNode, $this->result);
+        /** @var ConditionTree $tree */
+        $tree = GeneralUtility::makeInstance(ConditionTree::class, $rootNode, $this->result);
+
+        return $tree;
     }
 
     /**
@@ -95,7 +98,7 @@ class ConditionParser implements SingletonInterface
         $this->result = GeneralUtility::makeInstance(Result::class);
 
         $this->scope = $this->getNewScope();
-        $this->scope->setExpression($this->splitConditionExpression($condition->getCondition()));
+        $this->scope->setExpression($this->splitConditionExpression($condition->getExpression()));
     }
 
     /**
@@ -230,10 +233,10 @@ class ConditionParser implements SingletonInterface
      */
     private function processTokenCondition($condition)
     {
-        if (false === $this->condition->hasItem($condition)) {
+        if (false === $this->condition->hasCondition($condition)) {
             $this->addError('The condition "' . $condition . '" does not exist.', 1457628378);
         } else {
-            $node = new ConditionNode($condition, $this->condition->getItem($condition));
+            $node = new ConditionNode($condition, $this->condition->getCondition($condition));
             $this->scope
                 ->setNode($node)
                 ->shiftExpression();

--- a/Classes/Condition/Parser/ConditionParserFactory.php
+++ b/Classes/Condition/Parser/ConditionParserFactory.php
@@ -43,8 +43,8 @@ class ConditionParserFactory implements SingletonInterface
     {
         $hash = 'condition-tree-' .
             sha1(serialize([
-                $condition->getCondition(),
-                $condition->getItems()
+                $condition->getExpression(),
+                $condition->getConditions()
             ]));
 
         if (false === array_key_exists($hash, $this->trees)) {

--- a/Classes/Configuration/Form/Condition/Activation/Activation.php
+++ b/Classes/Configuration/Form/Condition/Activation/Activation.php
@@ -19,5 +19,5 @@ class Activation extends AbstractActivation
      * @var string
      * @validate NotEmpty
      */
-    protected $condition;
+    protected $expression;
 }

--- a/Classes/Configuration/Form/Condition/Activation/ActivationInterface.php
+++ b/Classes/Configuration/Form/Condition/Activation/ActivationInterface.php
@@ -13,7 +13,7 @@
 
 namespace Romm\Formz\Configuration\Form\Condition\Activation;
 
-use Romm\Formz\Condition\Items\AbstractConditionItem;
+use Romm\Formz\Condition\Items\ConditionItemInterface;
 
 /**
  * Interface which must be implemented by the activation classes which will be
@@ -27,30 +27,36 @@ interface ActivationInterface
      *
      * @return string
      */
-    public function getCondition();
+    public function getExpression();
+
+    /**
+     * @param string $expression
+     * @return void
+     */
+    public function setExpression($expression);
 
     /**
      * Returns the condition items.
      *
-     * @return AbstractConditionItem[]
+     * @return ConditionItemInterface[]
      */
-    public function getItems();
+    public function getConditions();
 
     /**
      * Returns true if the given item exists.
      *
-     * @param string $itemName Name of the item.
+     * @param string $name Name of the item.
      * @return bool
      */
-    public function hasItem($itemName);
+    public function hasCondition($name);
 
     /**
      * Return the item with the given name.
      *
-     * @param string $itemName Name of the item.
-     * @return AbstractConditionItem
+     * @param string $name Name of the item.
+     * @return ConditionItemInterface
      */
-    public function getItem($itemName);
+    public function getCondition($name);
 
     /**
      * @return ActivationUsageInterface
@@ -59,6 +65,7 @@ interface ActivationInterface
 
     /**
      * @param ActivationUsageInterface $rootObject
+     * @return void
      */
     public function setRootObject(ActivationUsageInterface $rootObject);
 }

--- a/Classes/Configuration/Form/Condition/Activation/ActivationResolver.php
+++ b/Classes/Configuration/Form/Condition/Activation/ActivationResolver.php
@@ -30,7 +30,7 @@ class ActivationResolver extends AbstractActivation implements MixedTypesInterfa
     final public static function getInstanceClassName(MixedTypesResolver $resolver)
     {
         $data = $resolver->getData();
-        $objectType = (empty(trim($data['condition'])))
+        $objectType = (empty(trim($data['expression'])))
             ? EmptyActivation::class
             : Activation::class;
 

--- a/Classes/Validation/Validator/Internal/ConditionIsValidValidator.php
+++ b/Classes/Validation/Validator/Internal/ConditionIsValidValidator.php
@@ -36,7 +36,7 @@ class ConditionIsValidValidator extends AbstractValidator
                 'validator.form.condition_is_valid.error',
                 'formz',
                 [
-                    $condition->getCondition(),
+                    $condition->getExpression(),
                     $conditionTree->getValidationResult()->getFirstError()->getMessage()
                 ]
             );

--- a/Documentation/03-Tutorial/Index.rst
+++ b/Documentation/03-Tutorial/Index.rst
@@ -121,7 +121,7 @@ You must follow the explanations of the chapter “:ref:`usersManual`” to conf
                             required < config.tx_formz.validators.required
                         }
 
-                        activation.condition = someFieldIsValid
+                        activation.expression = someFieldIsValid
                     }
                 }
             }

--- a/Documentation/04-DeveloperManual/JavaScript/Field.rst
+++ b/Documentation/04-DeveloperManual/JavaScript/Field.rst
@@ -126,7 +126,7 @@ Add an activation condition
 
         .. note::
 
-            This function is used by Formz core, in code automatically generated from values written in the TypoScript configuration of the :ref:`fields activation conditions <fieldsActivation-condition>`.
+            This function is used by Formz core, in code automatically generated from values written in the TypoScript configuration of the :ref:`fields activation conditions <fieldsActivation-expression>`.
 
 .. _developerManual-javaScript-field-addActivationConditionForValidator:
 

--- a/Documentation/05-UsersManual/TypoScript/ConfigurationActivation/Index.rst
+++ b/Documentation/05-UsersManual/TypoScript/ConfigurationActivation/Index.rst
@@ -61,7 +61,7 @@ Activation condition list
 
 You can find below the list of all activation condition available in Formz core.
 
-They can be used by fields (see “:ref:`Activation conditions <fieldsActivation-items>`”) and validators (see “:ref:`Validator activation <validatorsActivation>`”).
+They can be used by fields (see “:ref:`Activation conditions <fieldsActivation-conditions>`”) and validators (see “:ref:`Validator activation <validatorsActivation>`”).
 
 .. toctree::
     :maxdepth: 5

--- a/Documentation/05-UsersManual/TypoScript/ConfigurationFields.rst
+++ b/Documentation/05-UsersManual/TypoScript/ConfigurationFields.rst
@@ -28,9 +28,9 @@ Property                                                                        
 
 :ref:`behaviours <fieldsBehaviours>`                                                    Field behaviours
 
-:ref:`activation.items <fieldsActivation-items>`                                        Activation conditions
+:ref:`activation.conditions <fieldsActivation-conditions>`                              Activation conditions
 
-:ref:`activation.condition <fieldsActivation-condition>`                                Field activation expression
+:ref:`activation.expression <fieldsActivation-expression>`                              Field activation expression
 
 :ref:`settings.fieldContainerSelector <fieldsSettings-fieldContainerSelector>`          Field container selector
 
@@ -110,7 +110,7 @@ Field behaviours
 
             Note that the validators configurations are fetched directly from ``config.tx_formz.behaviours``. It prevents a configuration duplication when the behaviours are used at several places.
 
-.. _fieldsActivation-items:
+.. _fieldsActivation-conditions:
 
 Activation conditions
 ---------------------
@@ -118,7 +118,7 @@ Activation conditions
 .. container:: table-row
 
     Property
-        ``activation.items``
+        ``activation.conditions``
     Required?
         No
     Description
@@ -138,7 +138,7 @@ Activation conditions
                 }
             }
 
-.. _fieldsActivation-condition:
+.. _fieldsActivation-expression:
 
 Field activation
 ----------------
@@ -146,7 +146,7 @@ Field activation
 .. container:: table-row
 
     Property
-        ``activation.condition``
+        ``activation.expression``
     Required?
         No
     Description

--- a/Documentation/05-UsersManual/TypoScript/ConfigurationForms.rst
+++ b/Documentation/05-UsersManual/TypoScript/ConfigurationForms.rst
@@ -61,7 +61,7 @@ Activation conditions
     Required?
         No
     Description
-        Contains the list of activation conditions which are usable by all the fields of this form. These conditions may then be used in the activation logical expressions of a field (see “:ref:`fieldsActivation-condition`”) or a field validation.
+        Contains the list of activation conditions which are usable by all the fields of this form. These conditions may then be used in the activation logical expressions of a field (see “:ref:`fieldsActivation-expression`”) or a field validation.
 
         For more information on this, read the chapter “:ref:`usersManual-typoScript-configurationActivation`”.
 

--- a/Documentation/05-UsersManual/TypoScript/ConfigurationValidators.rst
+++ b/Documentation/05-UsersManual/TypoScript/ConfigurationValidators.rst
@@ -137,7 +137,7 @@ Validator activation
     Required?
         No
     Description
-        It is possible to activate a validator only in certain cases. The principle is exactly the same of the fields activation, see “:ref:`Conditions d'activation <fieldsActivation-items>`” and “:ref:`Activation du champ <fieldsActivation-condition>`”.
+        It is possible to activate a validator only in certain cases. The principle is exactly the same of the fields activation, see “:ref:`Conditions d'activation <fieldsActivation-conditions>`” and “:ref:`Activation du champ <fieldsActivation-expression>`”.
 
         Example — activating the rule ``required`` of the field ``passwordRepeat`` only when the field ``password`` is valid:
 

--- a/Documentation/07-CheatSheets/TypoScriptCheatSheet.rst
+++ b/Documentation/07-CheatSheets/TypoScriptCheatSheet.rst
@@ -124,7 +124,7 @@ You can find details of the properties at the chapter “:ref:`usersManual-typoS
 
                         # The field is activated only when the field `password`
                         # is valid.
-                        activation.condition = passwordIsValid
+                        activation.expression = passwordIsValid
                     }
                 }
             }

--- a/Documentation/Localization.fr_FR/03-Tutorial/Index.rst
+++ b/Documentation/Localization.fr_FR/03-Tutorial/Index.rst
@@ -121,7 +121,7 @@ Vous devrez donc suivre les indications du chapitre « :ref:`usersManual` » pou
                             required < config.tx_formz.validators.required
                         }
 
-                        activation.condition = someFieldIsValid
+                        activation.expression = someFieldIsValid
                     }
                 }
             }

--- a/Documentation/Localization.fr_FR/04-DeveloperManual/JavaScript/Field.rst
+++ b/Documentation/Localization.fr_FR/04-DeveloperManual/JavaScript/Field.rst
@@ -126,7 +126,7 @@ Rajouter une condition d'activation
 
         .. note::
 
-            Cette fonction est appelée par le cœur de Formz, dans du code généré automatiquement à partir des valeurs contenus dans la configuration TypoScript des :ref:`conditions d'activations de champs <fieldsActivation-condition>`.
+            Cette fonction est appelée par le cœur de Formz, dans du code généré automatiquement à partir des valeurs contenus dans la configuration TypoScript des :ref:`conditions d'activations de champs <fieldsActivation-expression>`.
 
 .. _developerManual-javaScript-field-addActivationConditionForValidator:
 

--- a/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationActivation/Index.rst
+++ b/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationActivation/Index.rst
@@ -61,7 +61,7 @@ Liste des conditions d'activation
 
 Retrouvez ci-dessous la liste des conditions d'activation disponibles dans le cœur de Formz.
 
-Elles peuvent être utilisées par les champs (cf. « :ref:`Conditions d'activation <fieldsActivation-items>` ») et les validateurs (cf « :ref:`Activation du validateur <validatorsActivation>` »).
+Elles peuvent être utilisées par les champs (cf. « :ref:`Conditions d'activation <fieldsActivation-conditions>` ») et les validateurs (cf « :ref:`Activation du validateur <validatorsActivation>` »).
 
 .. toctree::
     :maxdepth: 5

--- a/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationFields.rst
+++ b/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationFields.rst
@@ -28,9 +28,9 @@ Propriété                                                                     
 
 :ref:`behaviours <fieldsBehaviours>`                                                    Comportements du champ
 
-:ref:`activation.items <fieldsActivation-items>`                                        Conditions d'activation
+:ref:`activation.conditions <fieldsActivation-conditions>`                              Conditions d'activation
 
-:ref:`activation.condition <fieldsActivation-condition>`                                Expression d'activation du champ
+:ref:`activation.expression <fieldsActivation-expression>`                              Expression d'activation du champ
 
 :ref:`settings.fieldContainerSelector <fieldsSettings-fieldContainerSelector>`          Sélecteur du conteneur du champ
 
@@ -110,7 +110,7 @@ Comportements du champ
 
             Notez que les configurations des comportements sont récupérées directement de ``config.tx_formz.behaviours``. Cela empêche une redondance de configuration lorsque les comportements sont utilisés à plusieurs endroits.
 
-.. _fieldsActivation-items:
+.. _fieldsActivation-conditions:
 
 Conditions d'activation
 -----------------------
@@ -118,7 +118,7 @@ Conditions d'activation
 .. container:: table-row
 
     Propriété
-        ``activation.items``
+        ``activation.conditions``
     Requis ?
         Non
     Description
@@ -138,7 +138,7 @@ Conditions d'activation
                 }
             }
 
-.. _fieldsActivation-condition:
+.. _fieldsActivation-expression:
 
 Activation du champ
 -------------------
@@ -146,7 +146,7 @@ Activation du champ
 .. container:: table-row
 
     Propriété
-        ``activation.condition``
+        ``activation.expression``
     Requis ?
         Non
     Description

--- a/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationForms.rst
+++ b/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationForms.rst
@@ -61,7 +61,7 @@ Conditions d'activation
     Requis ?
         Non
     Description
-        Contient la liste des conditions d'activation qui seront utilisables par tous les champs de ce formulaire. Ces différentes conditions pourront ensuite être utilisées dans les expressions logiques d'activation d'un champ (cf. « :ref:`fieldsActivation-condition` ») ou d'une validation de champ.
+        Contient la liste des conditions d'activation qui seront utilisables par tous les champs de ce formulaire. Ces différentes conditions pourront ensuite être utilisées dans les expressions logiques d'activation d'un champ (cf. « :ref:`fieldsActivation-expression` ») ou d'une validation de champ.
 
         Pour plus d'informations sur ce fonctionnement, consultez le chapitre « :ref:`usersManual-typoScript-configurationActivation` ».
 

--- a/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationValidators.rst
+++ b/Documentation/Localization.fr_FR/05-UsersManual/TypoScript/ConfigurationValidators.rst
@@ -139,7 +139,7 @@ Activation du validateur
     Requis ?
         Non
     Description
-        Il est possible d'activer un validateur seulement dans certains cas. Le principe est exactement le même que l'activation des champs, voir « :ref:`Conditions d'activation <fieldsActivation-items>` » et « :ref:`Activation du champ <fieldsActivation-condition>` ».
+        Il est possible d'activer un validateur seulement dans certains cas. Le principe est exactement le même que l'activation des champs, voir « :ref:`Conditions d'activation <fieldsActivation-conditions>` » et « :ref:`Activation du champ <fieldsActivation-expression>` ».
 
         Exemple — on active la règle ``required`` du champ ``passwordRepeat`` seulement lorsque le champ ``password`` est valide :
 

--- a/Documentation/Localization.fr_FR/07-CheatSheets/TypoScriptCheatSheet.rst
+++ b/Documentation/Localization.fr_FR/07-CheatSheets/TypoScriptCheatSheet.rst
@@ -125,7 +125,7 @@ Vous pouvez retrouvez tous les détails des propriétés au chapitre « :ref:`us
 
                         # On active ce champ seulement lorsque le champ
                         # `password` est valide.
-                        activation.condition = passwordIsValid
+                        activation.expression = passwordIsValid
                     }
                 }
             }

--- a/Tests/Unit/AssetHandler/Css/FieldsActivationCssAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/Css/FieldsActivationCssAssetHandlerTest.php
@@ -30,7 +30,7 @@ class FieldsActivationCssAssetHandlerTest extends AbstractUnitTest
             'fields'              => [
                 'foo' => [
                     'activation' => [
-                        'condition' => 'test'
+                        'expression' => 'test'
                     ]
                 ]
             ]

--- a/Tests/Unit/AssetHandler/JavaScript/FieldsActivationJavaScriptAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/JavaScript/FieldsActivationJavaScriptAssetHandlerTest.php
@@ -32,7 +32,7 @@ TXT;
             'fields'              => [
                 'foo' => [
                     'activation' => [
-                        'condition' => 'test'
+                        'expression' => 'test'
                     ]
                 ]
             ]

--- a/Tests/Unit/AssetHandler/JavaScript/FieldsValidationActivationJavaScriptAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/JavaScript/FieldsValidationActivationJavaScriptAssetHandlerTest.php
@@ -34,7 +34,7 @@ TXT;
                     'validation' => [
                         'required' => [
                             'activation' => [
-                                'condition' => 'test'
+                                'expression' => 'test'
                             ]
                         ]
                     ]

--- a/Tests/Unit/AssetHandler/JavaScript/FieldsValidationJavaScriptAssetHandlerTest.php
+++ b/Tests/Unit/AssetHandler/JavaScript/FieldsValidationJavaScriptAssetHandlerTest.php
@@ -21,7 +21,7 @@ class FieldsValidationJavaScriptAssetHandlerTest extends AbstractUnitTest
     public function checkJavaScriptCode()
     {
         $expectedResult = <<<TXT
-(function(){Formz.Form.get('foo',function(form){varfield=null;field=form.getFieldByName('foo');if(null!==field){field.addValidation('required','Romm\\\\Formz\\\\Validation\\\\Validator\\\\RequiredValidator',{"options":[],"messages":{"default":"RommFormzTestsFixtureFormDefaultForm-foo-required-default"},"settings":{"className":"Romm\\\\Formz\\\\Validation\\\\Validator\\\\RequiredValidator","priority":null,"options":[],"messages":[],"activation":{"condition":null,"items":{"test":{"javaScriptFiles":["EXT:formz\/Resources\/Public\/JavaScript\/Conditions\/Formz.Condition.FieldIsValid.js"],"fieldName":"foo"}}},"useAjax":false,"validationName":"required"},"acceptsEmptyValues":false});}});})();
+(function(){Formz.Form.get('foo',function(form){varfield=null;field=form.getFieldByName('foo');if(null!==field){field.addValidation('required','Romm\\\\Formz\\\\Validation\\\\Validator\\\\RequiredValidator',{"options":[],"messages":{"default":"RommFormzTestsFixtureFormDefaultForm-foo-required-default"},"settings":{"className":"Romm\\\\Formz\\\\Validation\\\\Validator\\\\RequiredValidator","priority":null,"options":[],"messages":[],"activation":{"expression":null,"conditions":{"test":{"javaScriptFiles":["EXT:formz\/Resources\/Public\/JavaScript\/Conditions\/Formz.Condition.FieldIsValid.js"],"fieldName":"foo"}}},"useAjax":false,"validationName":"required"},"acceptsEmptyValues":false});}});})();
 TXT;
 
         $defaultFormConfiguration = [

--- a/Tests/Unit/Validation/Validator/Internal/ConditionIsValidValidatorTest.php
+++ b/Tests/Unit/Validation/Validator/Internal/ConditionIsValidValidatorTest.php
@@ -18,10 +18,10 @@ class ConditionIsValidValidatorTest extends AbstractUnitTest
 
         /** @var AbstractActivation|\PHPUnit_Framework_MockObject_MockObject $condition */
         $condition = $this->getMockBuilder(AbstractActivation::class)
-            ->setMethods(['getCondition'])
+            ->setMethods(['getExpression'])
             ->getMockForAbstractClass();
 
-        $condition->method('getCondition')
+        $condition->method('getExpression')
             ->willReturn('invalid condition expression');
 
         $result = $validator->validate($condition);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "romm/configuration-object": "^1.5",
+    "romm/configuration-object": "1.5.1a",
     "typo3/cms": "^6.2 || ^7.6.13 || ^8.5.0"
   },
   "require-dev": {


### PR DESCRIPTION
For the fields activation configuration, the keys `items` and `condition` have been changed to `conditions` and `expression`.

This makes more sense for what these configuration actually do.

A depreciation message has been added to help converting old configuration to the new one.