### PR TITLE
[TASK] Introduce new way of assets cache clearing

### DIFF
--- a/Classes/AssetHandler/Connector/AssetHandlerConnectorManager.php
+++ b/Classes/AssetHandler/Connector/AssetHandlerConnectorManager.php
@@ -155,7 +155,8 @@ class AssetHandlerConnectorManager
      */
     protected function fileExists($absolutePath)
     {
-        return file_exists($absolutePath);
+        return file_exists($absolutePath)
+            && 0 !== filemtime($absolutePath);
     }
 
     /**

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -136,8 +136,8 @@ class CacheService implements SingletonInterface
             return;
         }
 
-        foreach ($files as $assetCacheFile) {
-            unlink($assetCacheFile);
+        foreach ($files as $file) {
+            touch($file, 0);
         }
     }
 }


### PR DESCRIPTION
This commit changes the way the assets are cleared when the clear-caches command is done.

Previously, the files would all be deleted, to be created once again on the first request. This could lead to unwanted behaviours when using load balanced servers. If a server did clear shared caches when another server was dispatching a request (with `concatenate` configuration enabled), the resulting merged file could be incomplete due to Formz assets files missing. This wrong merged file would then be served at each request.

Now, the files are not deleted when caches are cleared: their modification time is forced to `0`, which allows current requests to still be able to access the file content.