### PR TITLE
[TASK] Optimization of the `Core::instantiate` method

### DIFF
--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -59,8 +59,14 @@ class Core implements SingletonInterface
     public static function instantiate($className)
     {
         $objectManager = self::get()->getObjectManager();
+        
+        $args = func_get_args();
+        
+        if (1 === count($args)) {
+            return $objectManager->get($className);
+        }
 
-        return call_user_func_array([$objectManager, 'get'], func_get_args());
+        return call_user_func_array([$objectManager, 'get'], $args);
     }
 
     /**

--- a/Classes/Core/Core.php
+++ b/Classes/Core/Core.php
@@ -59,9 +59,8 @@ class Core implements SingletonInterface
     public static function instantiate($className)
     {
         $objectManager = self::get()->getObjectManager();
-        
         $args = func_get_args();
-        
+
         if (1 === count($args)) {
             return $objectManager->get($className);
         }


### PR DESCRIPTION
The `Core::instanciate` method will directly call the `ObjectManager::get` method when no parameters are passed.

This avoids calling the function `call_user_func_array` most of the time.