### PR TITLE
[BUGFIX] Prevent getting unformatted input

### DIFF
--- a/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
+++ b/Resources/Public/JavaScript/Validators/Formz.Validator.Ajax.js
@@ -121,7 +121,7 @@
                 && null === key.match(/\[__referrer\]/)
             ) {
                 var value = getElementValue(form.elements[i]);
-                if (value) {
+                if (value && key.indexOf("[") !== -1) {
                     if ('' !== query) {
                         query += '&';
                     }


### PR DESCRIPTION
On an ajax call, FormZ will get all the input in the form tag and will
create the query. But if there is an input unformatted (without `[]`)
Formz will send a bad data.