### PR TITLE
[FEATURE] Add `fz-loading` to the `form` tag when a field is validating

### DIFF
--- a/Resources/Public/JavaScript/Field/Formz.Field.js
+++ b/Resources/Public/JavaScript/Field/Formz.Field.js
@@ -192,10 +192,13 @@ Fz.Field = (function () {
             handleLoadingBehaviour: function (run) {
                 var element = this.getFieldContainer();
                 if (null !== element) {
+                    var formElement = this.getForm().getElement();
                     if (true === run) {
                         element.setAttribute('fz-loading', '1');
+                        formElement.setAttribute('fz-loading', '1');
                     } else {
                         element.removeAttribute('fz-loading');
+                        formElement.removeAttribute('fz-loading');
                     }
                 }
             },


### PR DESCRIPTION
When any field starts its validation, the data attribute `fz-loading` is added to the `form` tag. When the validation is done (successful or not) the data attribute is removed.